### PR TITLE
Update the link to the Scala.js Benchmark project

### DIFF
--- a/index.md
+++ b/index.md
@@ -66,7 +66,7 @@ and follow the instructions in its readme.
 
 #### Miscellaneous
 
-*   [Port of the Dart benchmark harness](https://github.com/jonas/scalajs-benchmarks)
+*   [Port of the Dart benchmark harness](https://github.com/jonas/scala-js-benchmarks)
     by Jonas Fonseca
 
 ## Contribute


### PR DESCRIPTION
It was renamed to scala-js-benchmark to follow the convention used
by other Scala.js project.
