### PR TITLE
Add workbench-example-app to home page

### DIFF
--- a/index.md
+++ b/index.md
@@ -74,7 +74,7 @@ and follow the instructions in its readme.
 #### Tools
 
 *   [Scala.js workbench](https://github.com/lihaoyi/scala-js-workbench),
-    an sbt plugin for Scala.js projects for live-reloading in the browser, by Li Haoyi
+    an sbt plugin for Scala.js projects for live-reloading in the browser ([example app](https://github.com/lihaoyi/workbench-example-app)), by Li Haoyi
 
 *   [Scala.js Resource](https://github.com/lihaoyi/scala-js-resource), an sbt plugin for bundling of binary files so they can be accessed from the browser, by Li Haoyi
 
@@ -94,6 +94,10 @@ Want to contribute to Scala.js? Check out the
 
 Beginning a list of websites using Scala.js:
 
+*   February 2014
+
+    -   [Sierpinski Triangle](http://lihaoyi.github.io/workbench-example-app/triangle.html) and [Dodge the dot](http://lihaoyi.github.io/workbench-example-app/dodge.html) (Scala.js workbench [example apps](https://github.com/lihaoyi/workbench-example-app)), by Li Haoyi
+    
 *   December 2013
 
     -   [Roll](http://lihaoyi.github.io/roll/), a 2D Physics Platformer


### PR DESCRIPTION
Added links to the workbench-example-app repo, as well as to live demos of the two example apps themselves. A plug-and-play way of getting started with scala-js-workebench without having to wallow in SBT trying to set it up correctly.
