### PR TITLE
Fix formatting of Presentations section

### DIFF
--- a/index.md
+++ b/index.md
@@ -52,6 +52,7 @@ and not part of any of their support contracts. You have been warned!</p>
 *   [Scala.js tag on Stackoverflow](http://stackoverflow.com/questions/tagged/scala.js). Please help building it up by asking questions.
 
 Presentations:
+
 *   [Scala.js at Scaladays 2014](http://www.parleys.com/play/53a7d2cbe4b0543940d9e555), by Sébastien Doeraene 
 *   [Live Coding Scala.js at SF Scala 2014](http://vimeo.com/87845442) by Li Haoyi
 *   [Live-coding with Scala.js at Scala eXchange 2013](http://skillsmatter.com/podcast/scala/scala-js-write-in-scala-for-the-browser-4567)


### PR DESCRIPTION
Looks like the Jekyll markdown parser and the github-preview markdown parser behave differently in this case, and the jekyll parser doesn't like not having an empty line before the list items
