### PR TITLE
Announcing Scala.js 0.6.2.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ author :
   twitter : sjrdoeraene
   feedburner : feedname
 
-scalaJSVersion: 0.6.1
+scalaJSVersion: 0.6.2
 scalaJSBinaryVersion: 0.6
 
 # The production_url is only used when full-domain names are needed

--- a/_posts/news/2015-03-16-announcing-scalajs-0.6.2.md
+++ b/_posts/news/2015-03-16-announcing-scalajs-0.6.2.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: Announcing Scala.js 0.6.2
+category: news
+tags: [releases]
+---
+{% include JB/setup %}
+
+We are excited to announce the release of Scala.js 0.6.2!
+
+This release mostly contains bug fixes, among which the lack of support of `java.net.URI` for Unicode characters.
+It also brings code size reduction and performance improvements to fastOpt code (although nothing changes in fullOpt).
+
+We are also happy to share that Scala.js is now part of [Scala's community build](https://github.com/scala/community-builds).
+
+## Getting started
+
+If you are new to Scala.js, head over to
+[the tutorial]({{ BASE_PATH }}/doc/tutorial.html).
+
+## Release notes
+
+For changes in the 0.6.x series compared to 0.5.x, read [the announcement of 0.6.0]({{ BASE_PATH }}/news/2015/02/05/announcing-scalajs-0.6.0/).
+
+As a minor release, 0.6.2 is backward source and binary compatible with previous releases in the 0.6.x series.
+Libraries compiled with earlier versions can be used with 0.6.2 without change.
+
+We would like to remind you that libraries compiled with 0.6.0 will suffer from [bug #1506](https://github.com/scala-js/scala-js/issues/1506), which will cause `fastOptJS` in dependent projects to perform more work than necessary.
+It is therefore recommended for library authors to upgrade to Scala.js >= 0.6.1 and publish new versions of their libraries, if they haven't done so yet.
+Scala.js 0.6.0 can read binaries compiled with 0.6.1 and 0.6.2, so you need not be afraid to force an upgrade of all the users of your libraries.
+
+Please report any issues [on GitHub](https://github.com/scala-js/scala-js/issues).
+
+## Improvements
+
+* [A better translation to JavaScript](https://github.com/scala-js/scala-js/pull/1535) reduces the size of the `-fastopt.js` files by a few percent, and speeds up their execution.
+
+## Bug fixes
+
+* [#1520](https://github.com/scala-js/scala-js/issues/1520) `java.net.URI` does not support Unicode
+* [#1521](https://github.com/scala-js/scala-js/issues/1521) `new java.net.URI("#foo").getSchemeSpecificPart()` should return the empty String
+* [#1532](https://github.com/scala-js/scala-js/issues/1532) `TypedArrayByteBuffer.asDoubleBuffer` results in a "RangeError: Invalid typed array length"
+* [#1546](https://github.com/scala-js/scala-js/issues/1546) Error "Node.js isn't connected" when running on Travis (tentative fix)

--- a/doc/index.md
+++ b/doc/index.md
@@ -28,6 +28,16 @@ Generated Scaladocs are available here:
 
 ### Scala.js
 
+#### Scala.js 0.6.2
+* [0.6.2 scalajs-library]({{ site.production_url }}/api/scalajs-library/0.6.2/#scala.scalajs.js.package)
+* [0.6.2 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/0.6.2/)
+* [0.6.2 scalajs-stubs]({{ site.production_url }}/api/scalajs-stubs/0.6.2/)
+* [0.6.2 scalajs-ir]({{ site.production_url }}/api/scalajs-ir/0.6.2/#org.scalajs.core.ir.package)
+* [0.6.2 scalajs-tools]({{ site.production_url }}/api/scalajs-tools/0.6.2/#org.scalajs.core.tools.package) ([Scala.js version]({{ site.production_url }}/api/scalajs-tools-js/0.6.2/#org.scalajs.core.tools.package))
+* [0.6.2 scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/0.6.2/#org.scalajs.jsenv.package)
+* [0.6.2 scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/0.6.2/#org.scalajs.testadapter.package)
+* [0.6.2 sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/0.6.2/#org.scalajs.sbtplugin.package)
+
 #### Scala.js 0.6.1
 * [0.6.1 scalajs-library]({{ site.production_url }}/api/scalajs-library/0.6.1/#scala.scalajs.js.package)
 * [0.6.1 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/0.6.1/)

--- a/downloads.md
+++ b/downloads.md
@@ -9,6 +9,12 @@ We strongly recommend using the SBT plugin, as shown in the [bootstrapping skele
 
 The CLI distribution requires `scala` and `scalac` (of the right major version) to be on the execution path. Unpack it wherever you like and add the `bin/` folder to your execution path.
 
+#### Scala.js 0.6.2
+* [0.6.2, Scala 2.11 (tgz, 21MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.2.tgz)
+* [0.6.2, Scala 2.11 (zip, 21MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.2.zip)
+* [0.6.2, Scala 2.10 (tgz, 19MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.2.tgz)
+* [0.6.2, Scala 2.10 (zip, 19MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.2.zip)
+
 #### Scala.js 0.6.1
 * [0.6.1, Scala 2.11 (tgz, 20MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.1.tgz)
 * [0.6.1, Scala 2.11 (zip, 20MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.1.zip)

--- a/index.md
+++ b/index.md
@@ -182,6 +182,7 @@ List of websites using Scala.js:
 
 ## Version History
 
+- [0.6.2](/news/2015/03/16/announcing-scalajs-0.6.2/)
 - [0.6.1](/news/2015/03/03/announcing-scalajs-0.6.1/)
 - [0.6.0](/news/2015/02/05/announcing-scalajs-0.6.0/)
 - [0.6.0-RC2](/news/2015/01/23/announcing-scalajs-0.6.0-RC2/)


### PR DESCRIPTION
To be announced tomorrow morning CET, if all goes well.