### PR TITLE
Fix #152: Document option object pattern

### DIFF
--- a/doc/calling-javascript.md
+++ b/doc/calling-javascript.md
@@ -176,6 +176,29 @@ or as
 js.Dynamic.literal("foo" -> 42, "bar" -> "foobar")
 {% endhighlight %}
 
+### Literal object construction using an Scala object interface
+Sometimes for a nicer interface, literal objects can be implimented using 
+a trait interface. 
+The above JavaScript code can be implemented using following code:
+
+{% highlight scala %}
+trait MyObject extends js.Object {
+  val foo: Int = js.native
+  val bar: String = js.native
+}
+{% endhighlight %}
+
+A Scala object should be added for typesafe creation, it would help the readability 
+of the code by removing lots of `js.Dynamic.literal` all over the code. 
+
+{% highlight scala %}
+object MyObject{
+  def apply(foo: Int, bar: String): MyObject = {
+    js.Dynamic.literal(foo = foo, bar = bar).asInstanceOf[MyObject]
+  }
+}
+{% endhighlight %}
+
 ## Defining JavaScript interfaces with traits
 
 Most JavaScript APIs work with interfaces that are defined structurally. In


### PR DESCRIPTION
adding `Literal object construction using an scala object interface` section to address http://stackoverflow.com/questions/26638171/how-do-i-create-options-objects-in-scala-js

Fix #152: Document option object pattern