### PR TITLE
Add scalajs-createjs and scalajs-ace

### DIFF
--- a/index.md
+++ b/index.md
@@ -64,8 +64,8 @@ Some of them, like `scala-js-dom` and `scala-js-jquery`, are specific to Javascr
 Some others, such as `scala-async`, are pure-macro projects, and thus work with Scala.js out of the box.
 Most of them, though, are cross-compiling over JVM and JS, and thus have separate artifacts to run on each platform.
 
-If you have a library that would be useful to the Scala.js community, please 
-[add it to this list](https://github.com/scala-js/scala-js-website/edit/master/index.md)! 
+If you have a library that would be useful to the Scala.js community, please
+[add it to this list](https://github.com/scala-js/scala-js-website/edit/master/index.md)!
 Add a new entry for the library under the appropriate category below, press "Propose file change"
 and then "Create a Pull Request".
 
@@ -78,6 +78,8 @@ and then "Create a Pull Request".
 *   [bootstrap-datepicker-facade](https://github.com/jducoeur/bootstrap-datepicker-scalajs): static types for [bootstrap-datepicker](https://github.com/eternicode/bootstrap-datepicker)
 *   [scalajs-google-maps](https://github.com/coreyauger/scalajs-google-maps): static types for google maps v3
 *   [scala-js-vaadin-components](https://github.com/hezamu/scala-js-vaadin-components): static types for [Vaadin Components](http://vaadin.com/components)
+*   [scalajs-createjs](https://github.com/takezoe/scalajs-createjs): static types for [CreateJS](http://createjs.com/)
+*   [scalajs-ace](https://github.com/takezoe/scalajs-ace): static types for [Ace](http://ace.c9.io/)
 
 ### Testing frameworks
 


### PR DESCRIPTION
Add [scalajs-createjs](https://github.com/takezoe/scalajs-createjs) and [scalajs-ace](https://github.com/takezoe/scalajs-ace) to Static types for JavaScript libraries section.