### PR TITLE
Add Binding.scala

### DIFF
--- a/_data/library/scalalibs.yml
+++ b/_data/library/scalalibs.yml
@@ -24,8 +24,16 @@
       url: https://github.com/unicredit/akka.js
       desc: Toolkit and runtime for building concurrent, distributed applications
       dep: ''
+    - name: Binding.scala/core
+      url: https://github.com/ThoughtWorksInc/Binding.scala
+      desc: Reactive data-binding for both Scala.js and JVM
+      dep: 'libraryDependencies += "com.thoughtworks.binding" %%% "core" % "1.0.5"'
 - topic: Web libraries/frameworks
   libraries:
+    - name: Binding.scala/dom
+      url: https://github.com/ThoughtWorksInc/Binding.scala
+      desc: Reactive web framework for Scala.js
+      dep: 'libraryDependencies += "com.thoughtworks.binding" %%% "dom" % "1.0.5"'
     - name: Scalatags
       url: https://github.com/lihaoyi/scalatags
       desc: HTML templating library/DSL that works on both Scala/JVM and Scala.js

--- a/_data/library/scalalibs.yml
+++ b/_data/library/scalalibs.yml
@@ -24,10 +24,6 @@
       url: https://github.com/unicredit/akka.js
       desc: Toolkit and runtime for building concurrent, distributed applications
       dep: ''
-    - name: Binding.scala/core
-      url: https://github.com/ThoughtWorksInc/Binding.scala
-      desc: Reactive data-binding for both Scala.js and JVM
-      dep: 'libraryDependencies += "com.thoughtworks.binding" %%% "core" % "1.0.5"'
 - topic: Web libraries/frameworks
   libraries:
     - name: Binding.scala/dom
@@ -100,6 +96,10 @@
       url: https://github.com/MetaStack-pl/MetaRx
       desc: Reactive data structures for Scala and Scala.js
       dep: '"pl.metastack" %%% "metarx" % "0.1.3"'
+    - name: Binding.scala/core
+      url: https://github.com/ThoughtWorksInc/Binding.scala
+      desc: Reactive data-binding for both Scala.js and JVM
+      dep: 'libraryDependencies += "com.thoughtworks.binding" %%% "core" % "1.0.5"'
 - topic: Miscellaneous
   libraries:
     - name: NICTA/rng


### PR DESCRIPTION
Recently we open-sourced [Binding.scala](https://github.com/ThoughtWorksInc/Binding.scala), which is a data-binding framework for [Scala](http://www.scala-lang.org/) JVM and [Scala.js](http://www.scala-js.org/).

Binding.scala can be used as a **[reactive](https://en.wikipedia.org/wiki/Reactive_programming) web framework**.
It enables you use native XML literal syntax to create reactive DOM nodes,
which are able to automatically change whenever the data source changes.