### PR TITLE
Use origin.scala-js.org for deployment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
 script:
   - jekyll build
 after_success:
-  - if [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "master" && "${DEPLOY_USER}" != "" && "${DEPLOY_PASS}" != "" ]]; then sudo apt-get update -qq; sudo apt-get install -qq sshpass; sshpass -p "${DEPLOY_PASS}" rsync -e "ssh -o StrictHostKeyChecking=no" -atv _site/ "${DEPLOY_USER}@scala-js.org:www/"; fi
+  - if [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "master" && "${DEPLOY_USER}" != "" && "${DEPLOY_PASS}" != "" ]]; then sudo apt-get update -qq; sudo apt-get install -qq sshpass; sshpass -p "${DEPLOY_PASS}" rsync -e "ssh -o StrictHostKeyChecking=no" -atv _site/ "${DEPLOY_USER}@origin.scala-js.org:www/"; fi
 env:
   global:
     - JEKYLL_ENV=production


### PR DESCRIPTION
Since now scala-js.org resolves to the CDN's caching servers, which do not like ssh connections.