### PR TITLE
Doc nav is now fully open to reveal all doc pages.

### DIFF
--- a/_includes/docnav.html
+++ b/_includes/docnav.html
@@ -11,7 +11,7 @@
             {% endif %}
         </a>
     </li>
-    {% if item.subitems and navurl contains item.url %}
+    {% if item.subitems %}
       {% include docnav.html nav=item.subitems %}
     {% endif %}
     {% endfor %}


### PR DESCRIPTION
Scala.js shields use HTTPS instead of HTTP.