### PR TITLE
Insert reference to new skeleton, play-scalajs-workbench-example

### DIFF
--- a/libraries/skeletons.md
+++ b/libraries/skeletons.md
@@ -12,8 +12,11 @@ browser, together with a collection of sample applications developed using it
 ### [SPA tutorial with Scala.js and React](https://github.com/ochrons/scalajs-spa-tutorial)
 Simple Single Page Application tutorial built upon scalajs-react, Play and Bootstrap.
 
-### [Play! application with Scala.js](https://github.com/vmunier/play-with-scalajs-example)
-Example application showing how you can integrate Play with Scala.js.
+### [Play application with Scala.js](https://github.com/vmunier/play-with-scalajs-example)
+Example application showing how you can integrate [Play](https://www.playframework.com/) with Scala.js.
+
+### [Play application with Scala.js and Workbench](https://github.com/aholland/play-scalajs-workbench-example)
+Example setup which, using the [Workbench plugin](https://github.com/lihaoyi/workbench), prevents any change made to client code from causing a compile error on the [Play](https://www.playframework.com/) server, which could otherwise slow down client development. 
 
 ### [Node.js module with Scala.js](https://github.com/rockymadden/scala-node-example)
 Proof of concept to determine if Scala.js could be leveraged to make a Node.js module.


### PR DESCRIPTION
PR created as per Otto Chrons' suggestion on https://gitter.im/scala-js/scala-js:
"**ochrons Mar 17 07:26** @aholland you should raise an issue/PR on scala-js-website to get that included on the site".

My concerns are
(1) Why does the other reference to Play (directly above mine) have an exclamation mark? Should mine also, or show that one not be there, or don't we care?
(2) Is my explanation too long?

Thanks,
Anthony

