### PR TITLE
Remove </img> after clipboard image

### DIFF
--- a/_includes/library.html
+++ b/_includes/library.html
@@ -20,7 +20,7 @@
                     <div class="div-clipboard">
                     <button class="btn btn-default btn-xs btn-clipboard" data-clipboard-text='{{ library.dep }}'
                             title='{{ library.dep }}'><img
-                        class="clippy" width="13" src="{{ "/assets/img/clippy.svg" | prepend: site.baseurl }}"></img></button>
+                        class="clippy" width="13" src="{{ "/assets/img/clippy.svg" | prepend: site.baseurl }}"></button>
                     </div>
                     {% endif %}
                 </td>


### PR DESCRIPTION
On my computer, I see a literal `</img>` string after the clipboard image on the [libraries page](https://www.scala-js.org/libraries/libs.html):
![screen shot 2016-06-10 at 5 19 20 pm](https://cloud.githubusercontent.com/assets/1883086/15979015/8eee5e92-2f2f-11e6-8c07-038de129ef7d.png)