### PR TITLE
Remove zcheck from test libs

### DIFF
--- a/_data/library/testlibs.yml
+++ b/_data/library/testlibs.yml
@@ -12,10 +12,6 @@
       url: https://github.com/monifu/minitest
       desc: A mini testing framework, cross-compiled for Scala and Scala.js
       dep: '"org.monifu" %%% "minitest" % "0.14" % "test"'
-    - name: zcheck
-      url: https://github.com/InTheNow/zcheck
-      desc: A wrapper around scalacheck and scalaz's Speclite.
-      dep: '"com.github.inthenow" %%% "zcheck" % "0.6.1"'
     - name: Greenlight
       url: https://github.com/greencatsoft/greenlight
       desc: BDD style testing framework for Scala and Scala.js.


### PR DESCRIPTION
InTheNow removed his GitHub user, so zcheck no longer exists. The closest is https://github.com/Nuriaion/zcheck, which was probably a fork, and doesn't contain the code for version 0.6.1