### PR TITLE
Improve ES6 vs. Scala.js examples

### DIFF
--- a/doc/interoperability/index.md
+++ b/doc/interoperability/index.md
@@ -26,7 +26,7 @@ xhr.onload = (e) => {
     var r = JSON.parse(xhr.responseText);
     $("#tweets").html(parseTweets(r));
   }
-}
+};
 {% endhighlight %}
 {% endcolumn %}
 

--- a/doc/interoperability/index.md
+++ b/doc/interoperability/index.md
@@ -27,6 +27,7 @@ xhr.onload = (e) => {
     $("#tweets").html(parseTweets(r));
   }
 };
+xhr.send();
 {% endhighlight %}
 {% endcolumn %}
 
@@ -44,6 +45,7 @@ xhr.onload = { (e: Event) =>
     $("#tweets").html(parseTweets(r))
   }
 }
+xhr.send()
 {% endhighlight %}
 {% endcolumn %}
 {% endcolumns %}

--- a/doc/sjs-for-js/index.md
+++ b/doc/sjs-for-js/index.md
@@ -19,7 +19,7 @@ xhr.onload = (e) => {
     var r = JSON.parse(xhr.responseText);
     $("#tweets").html(parseTweets(r));
   }
-}
+};
 {% endhighlight %}
 {% endcolumn %}
 

--- a/doc/sjs-for-js/index.md
+++ b/doc/sjs-for-js/index.md
@@ -20,6 +20,7 @@ xhr.onload = (e) => {
     $("#tweets").html(parseTweets(r));
   }
 };
+xhr.send();
 {% endhighlight %}
 {% endcolumn %}
 
@@ -37,6 +38,7 @@ xhr.onload = { (e: Event) =>
     $("#tweets").html(parseTweets(r))
   }
 }
+xhr.send()
 {% endhighlight %}
 {% endcolumn %}
 {% endcolumns %}


### PR DESCRIPTION
* Fixes inconsistent semicolon usage in ES6 examples.

* Adds `xhr.send()`: I am aware that making the example longer is not desirable. However, this one additional line makes it more well rounded. Specifically, it prevents other copy/pasters from falling into the "why the hell is my listener not executing?!" trap.