### PR TITLE
Updated versions of scala-java-locales and scala-java-time

### DIFF
--- a/_data/library/scalalibs.yml
+++ b/_data/library/scalalibs.yml
@@ -9,13 +9,13 @@
       desc: Implementation of JDK8's [java.time API](https://docs.oracle.com/javase/8/docs/api/java/time/package-summary.html) in Scala.js by wrapping [js-joda](http://js-joda.github.io/js-joda/) classes
       dep: '"com.zoepepper" %%% "scalajs-jsjoda-as-java-time" % "1.0.5"'
     - name: scala-java-time
-      url: https://github.com/soc/scala-java-time
+      url: https://github.com/cquiroz/scala-java-time
       desc: Platform-independent implementation of [java.time](https://docs.oracle.com/javase/8/docs/api/java/time/package-summary.html)
-      dep: '"io.github.soc" %%% "scala-java-time" % "2.0.0-M1"'
+      dep: '"io.github.cquiroz" %%% "scala-java-time" % "2.0.0-M6"'
     - name: scala-java-locales
       url: https://github.com/cquiroz/scala-java-locales
-      desc: Implementation of JDK8's [java.util.Locale API](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html) and parts of [java.text API](https://docs.oracle.com/javase/8/docs/api/java/text/package-summary.html) compatible with Scala.js
-      dep: '"com.github.cquiroz" %%% "scala-java-locales" % "0.2.0+29"'
+      desc: Implementation of JDK8's [java.util.Locale API](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html) and parts of [java.text API](https://docs.oracle.com/javase/8/docs/api/java/text/package-summary.html)
+      dep: '"io.github.cquiroz" %%% "scala-java-locales" % "0.5.0+cldr30"'
     - name: scalajs-java-logging
       url: https://github.com/scala-js/scala-js-java-logging
       desc: Port of the [java.util.logging API](https://docs.oracle.com/javase/8/docs/api/java/util/logging/package-summary.html) of JDK 8 for Scala.js


### PR DESCRIPTION
Points to the latest versions of both libraries
Note that `scala-java-time` has changed organization