### PR TITLE
Update to the latest squants release

### DIFF
--- a/_data/library/scalalibs.yml
+++ b/_data/library/scalalibs.yml
@@ -220,9 +220,9 @@
       desc: 'CRON expression parser supporting multiple data-time libraries in the JVM and in the browser'
       dep: '"com.github.alonsodomin.cron4s" %%% "cron4s" % "0.1.0"'
     - name: squants
-      url: https://github.com/garyKeorkunian/squants
+      url: https://github.com/typelevel/squants
       desc: 'API for Quantities, Units of Measure and Dimensional Analysis'
-      dep: '"com.squants" %%% "squants" % "0.6.2'
+      dep: '"org.typelevel" %%% "squants" % "1.0.0'
 - topic: Tools
   libraries:
     - name: sbt-scala-js-map


### PR DESCRIPTION
Note that squants now lives under `org.typelevel`