### PR TITLE
Update description for scalajs-reactjs

### DIFF
--- a/_data/library/jsfacades.yml
+++ b/_data/library/jsfacades.yml
@@ -104,7 +104,7 @@
       dep: '"com.github.japgolly.scalajs-react" %%% "core" % "0.10.0"'
     - name: scalajs-reactjs
       url: https://github.com/shogowada/scalajs-reactjs
-      desc: Develop React applications in Scala using familiar APIs close to the original React's APIs
+      desc: 'Develop React applications in Scala with APIs close to the original: react, react-router, and react-redux facade'
       dep: '"io.github.shogowada" %%% "scalajs-reactjs" % "0.4.3"'
     - name: scala-js-binding
       url: https://github.com/antonkulaga/scala-js-binding


### PR DESCRIPTION
scalajs-reactjs now includes facade for react-redux too. This updates the description so that it communicates what's actually included.