### PR TITLE
Update scaladget javascript library

### DIFF
--- a/_data/library/jsfacades.yml
+++ b/_data/library/jsfacades.yml
@@ -66,8 +66,8 @@
       dep: '"org.singlespaced" %%% "scalajs-d3" % "0.3.4"'
     - name: scaladget
       url: https://github.com/mathieuleclaire/scaladget
-      desc: Static types for [D3.js](http://d3js.org), [Ace](http://ace.c9.io), [Tooltipster](http://iamceege.github.io/tooltipster/),  [Bootstrap.js](http://getbootstrap.com/) (and an API for the latter)
-      dep: '"fr.iscpif" %%% "scaladget" % "0.7.0"'
+      desc: Static types for [D3.js](http://d3js.org), [Ace](http://ace.c9.io),  [Bootstrap-native.js](https://thednp.github.io/bootstrap.native/) (and an API for the latter)
+      dep: '"fr.iscpif" %%% "scaladget" % "0.9.2"'
     - name: Paths.scala.js
       url: https://github.com/andreaferretti/paths-scala-js
       desc: A library to generate SVG charts and shapes (wrapper over [Paths.js](https://github.com/andreaferretti/paths-js))


### PR DESCRIPTION
Upadate Scaladget version and content (now wraps bootstrap-native js lib rather than bootstrap lib)