### PR TITLE
Announcing Scala.js 0.6.19.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ colors:  #in hex code if not noted else
 
 ### VERSIONS ###
 versions:
-  scalaJS: 0.6.18
+  scalaJS: 0.6.19
   scalaJSBinary: 0.6
   scalaJSDev: 1.0.0-M1
   scalaJSDevBinary: 1.0.0-M1

--- a/_posts/news/2017-07-29-announcing-scalajs-0.6.19.md
+++ b/_posts/news/2017-07-29-announcing-scalajs-0.6.19.md
@@ -1,0 +1,49 @@
+---
+layout: post
+title: Announcing Scala.js 0.6.19
+category: news
+tags: [releases]
+permalink: /news/2017/07/29/announcing-scalajs-0.6.19/
+---
+
+
+We are pleased to announce the release of Scala.js 0.6.19!
+
+This release brings support for [sbt 1.0.0-RC2](http://www.scala-sbt.org/1.0/docs/sbt-1.0-Release-Notes.html#sbt+1.0.0-RC2) and following.
+In addition, it fixes a few compiler issues.
+
+Read on for more details.
+
+<!--more-->
+
+## Getting started
+
+If you are new to Scala.js, head over to
+[the tutorial]({{ BASE_PATH }}/tutorial/).
+
+## Release notes
+
+If upgrading from Scala.js 0.6.14 or earlier, make sure to read [the release notes of 0.6.15]({{ BASE_PATH }}/news/2017/03/21/announcing-scalajs-0.6.15/), which contain important migration information.
+
+As a minor release, 0.6.19 is backward source and binary compatible with previous releases in the 0.6.x series.
+Libraries compiled with earlier versions can be used with 0.6.19 without change.
+0.6.19 is also forward binary compatible with 0.6.{17-18}, but not with earlier releases: libraries compiled with 0.6.19 cannot be used by projects using 0.6.{0-16}.
+
+Please report any issues [on GitHub](https://github.com/scala-js/scala-js/issues).
+
+## New features
+
+### Support for sbt 1.0.0-RC2 and following
+
+You can now use Scala.js 0.6.19 with [sbt 1.0.0-RC2](http://www.scala-sbt.org/1.0/docs/sbt-1.0-Release-Notes.html#sbt+1.0.0-RC2), and following releases of sbt.
+Nothing changes in sbt-scalajs between sbt 0.13.x and sbt 1.x.
+
+## Bug fixes
+
+Among others, the following bugs have been fixed in 0.6.19:
+
+* [#3053](https://github.com/scala-js/scala-js/issues/3053) "`java.util.NoSuchElementException`: key not found: null" while optimizing (root cause: [#3055](https://github.com/scala-js/scala-js/issues/3055))
+* [#3050](https://github.com/scala-js/scala-js/issues/3050) No linking error reported for conflicting export names with `@JSExportTopLevel object`.
+* [#3047](https://github.com/scala-js/scala-js/issues/3047) Two methods with the same JS name must not compile
+
+You can find the full list [on GitHub](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av0.6.19+is%3Aclosed).

--- a/doc/all-api.md
+++ b/doc/all-api.md
@@ -5,6 +5,17 @@ title: All previous versions of the Scala.js API
 
 ## All previous versions of the API
 
+### Scala.js 0.6.19
+* [0.6.19 scalajs-library]({{ site.production_url }}/api/scalajs-library/0.6.19/#scala.scalajs.js.package)
+* [0.6.19 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/0.6.19/)
+* [0.6.19 scalajs-stubs]({{ site.production_url }}/api/scalajs-stubs/0.6.19/)
+* [0.6.19 scalajs-ir]({{ site.production_url }}/api/scalajs-ir/0.6.19/#org.scalajs.core.ir.package)
+* [0.6.19 scalajs-tools]({{ site.production_url }}/api/scalajs-tools/0.6.19/#org.scalajs.core.tools.package) ([Scala.js version]({{ site.production_url }}/api/scalajs-tools-js/0.6.19/#org.scalajs.core.tools.package))
+* [0.6.19 scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/0.6.19/#org.scalajs.jsenv.package)
+* [0.6.19 scalajs-js-envs-test-kit]({{ site.production_url }}/api/scalajs-js-envs-test-kit/0.6.19/#org.scalajs.jsenv.test.package)
+* [0.6.19 scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/0.6.19/#org.scalajs.testadapter.package)
+* [0.6.19 sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/0.6.19/#org.scalajs.sbtplugin.package)
+
 ### Scala.js 1.0.0-M1
 * [1.0.0-M1 scalajs-library]({{ site.production_url }}/api/scalajs-library/1.0.0-M1/scala/scalajs/js/index.html)
 * [1.0.0-M1 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/1.0.0-M1/)

--- a/doc/internals/downloads.md
+++ b/doc/internals/downloads.md
@@ -7,6 +7,14 @@ We strongly recommend using the SBT plugin, as shown in the [bootstrapping skele
 
 The CLI distribution requires `scala` and `scalac` (of the right major version) to be on the execution path. Unpack it wherever you like and add the `bin/` folder to your execution path.
 
+#### Scala.js 0.6.19
+* [0.6.19, Scala 2.12 (tgz, 16MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.19.tgz)
+* [0.6.19, Scala 2.12 (zip, 16MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.19.zip)
+* [0.6.19, Scala 2.11 (tgz, 28MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.19.tgz)
+* [0.6.19, Scala 2.11 (zip, 29MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.19.zip)
+* [0.6.19, Scala 2.10 (tgz, 23MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.19.tgz)
+* [0.6.19, Scala 2.10 (zip, 23MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.19.zip)
+
 #### Scala.js 1.0.0-M1
 * [1.0.0-M1, Scala 2.12 (tgz, 15MB)]({{ site.production_url }}/files/scalajs_2.12-1.0.0-M1.tgz)
 * [1.0.0-M1, Scala 2.12 (zip, 15MB)]({{ site.production_url }}/files/scalajs_2.12-1.0.0-M1.zip)

--- a/doc/internals/version-history.md
+++ b/doc/internals/version-history.md
@@ -5,6 +5,7 @@ title: Version history
 
 ## Version history of Scala.js
 
+- [0.6.19](/news/2017/07/29/announcing-scalajs-0.6.19/)
 - [1.0.0-M1](/news/2017/07/03/announcing-scalajs-1.0.0-M1/)
 - [0.6.18](/news/2017/06/28/announcing-scalajs-0.6.18/)
 - [0.6.17](/news/2017/06/04/announcing-scalajs-0.6.17/)


### PR DESCRIPTION
To be announced tomorrow, end of day probably.