### PR TITLE
Announcing Scala.js 0.6.21.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ colors:  #in hex code if not noted else
 
 ### VERSIONS ###
 versions:
-  scalaJS: 0.6.20
+  scalaJS: 0.6.21
   scalaJSBinary: 0.6
   scalaJSDev: 1.0.0-M1
   scalaJSDevBinary: 1.0.0-M1

--- a/_posts/news/2017-11-06-announcing-scalajs-0.6.21.md
+++ b/_posts/news/2017-11-06-announcing-scalajs-0.6.21.md
@@ -1,0 +1,51 @@
+---
+layout: post
+title: Announcing Scala.js 0.6.21
+category: news
+tags: [releases]
+permalink: /news/2017/11/06/announcing-scalajs-0.6.21/
+---
+
+
+We are pleased to announce the release of Scala.js 0.6.21!
+
+This release is almost exclusively a bug-fix release.
+
+Read on for more details.
+
+<!--more-->
+
+## Getting started
+
+If you are new to Scala.js, head over to
+[the tutorial]({{ BASE_PATH }}/tutorial/).
+
+## Release notes
+
+If upgrading from Scala.js 0.6.14 or earlier, make sure to read [the release notes of 0.6.15]({{ BASE_PATH }}/news/2017/03/21/announcing-scalajs-0.6.15/), which contain important migration information.
+
+As a minor release, 0.6.21 is backward source and binary compatible with previous releases in the 0.6.x series.
+Libraries compiled with earlier versions can be used with 0.6.21 without change.
+0.6.21 is also forward binary compatible with 0.6.{17-20}, but not with earlier releases: libraries compiled with 0.6.21 cannot be used by projects using 0.6.{0-16}.
+
+Please report any issues [on GitHub](https://github.com/scala-js/scala-js/issues).
+
+## New features
+
+### JDK APIs
+
+The following JDK API methods have been added:
+
+* `java.lang.StringBuilder.delete`
+* `java.lang.StringBuffer.delete`
+
+## Bug fixes
+
+The following bugs have been fixed in 0.6.21:
+
+* [#3125](https://github.com/scala-js/scala-js/issues/3125) `println("\u0007")` renders as the character `"a"`
+* [#3128](https://github.com/scala-js/scala-js/issues/3128) Scala.js 0.6.20 breaks Java 7 builds (`NoSuchMethodError: java.util.concurrent.ConcurrentHashMap.keySet`)
+* [#3134](https://github.com/scala-js/scala-js/issues/3134) `regex.Matcher.start(group)` and friends report wrong positions
+* [#3135](https://github.com/scala-js/scala-js/issues/3135) Relative path to source file in sourcemap is sometimes broken
+
+You can find the full list [on GitHub](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av0.6.21+is%3Aclosed).

--- a/doc/all-api.md
+++ b/doc/all-api.md
@@ -5,6 +5,17 @@ title: All previous versions of the Scala.js API
 
 ## All previous versions of the API
 
+### Scala.js 0.6.21
+* [0.6.21 scalajs-library]({{ site.production_url }}/api/scalajs-library/0.6.21/#scala.scalajs.js.package)
+* [0.6.21 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/0.6.21/)
+* [0.6.21 scalajs-stubs]({{ site.production_url }}/api/scalajs-stubs/0.6.21/)
+* [0.6.21 scalajs-ir]({{ site.production_url }}/api/scalajs-ir/0.6.21/#org.scalajs.core.ir.package)
+* [0.6.21 scalajs-tools]({{ site.production_url }}/api/scalajs-tools/0.6.21/#org.scalajs.core.tools.package) ([Scala.js version]({{ site.production_url }}/api/scalajs-tools-js/0.6.21/#org.scalajs.core.tools.package))
+* [0.6.21 scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/0.6.21/#org.scalajs.jsenv.package)
+* [0.6.21 scalajs-js-envs-test-kit]({{ site.production_url }}/api/scalajs-js-envs-test-kit/0.6.21/#org.scalajs.jsenv.test.package)
+* [0.6.21 scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/0.6.21/#org.scalajs.testadapter.package)
+* [0.6.21 sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/0.6.21/#org.scalajs.sbtplugin.package)
+
 ### Scala.js 0.6.20
 * [0.6.20 scalajs-library]({{ site.production_url }}/api/scalajs-library/0.6.20/#scala.scalajs.js.package)
 * [0.6.20 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/0.6.20/)

--- a/doc/internals/downloads.md
+++ b/doc/internals/downloads.md
@@ -7,6 +7,14 @@ We strongly recommend using the SBT plugin, as shown in the [bootstrapping skele
 
 The CLI distribution requires `scala` and `scalac` (of the right major version) to be on the execution path. Unpack it wherever you like and add the `bin/` folder to your execution path.
 
+#### Scala.js 0.6.21
+* [0.6.21, Scala 2.12 (tgz, 18MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.21.tgz)
+* [0.6.21, Scala 2.12 (zip, 18MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.21.zip)
+* [0.6.21, Scala 2.11 (tgz, 29MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.21.tgz)
+* [0.6.21, Scala 2.11 (zip, 29MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.21.zip)
+* [0.6.21, Scala 2.10 (tgz, 23MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.21.tgz)
+* [0.6.21, Scala 2.10 (zip, 23MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.21.zip)
+
 #### Scala.js 0.6.20
 * [0.6.20, Scala 2.12 (tgz, 17MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.20.tgz)
 * [0.6.20, Scala 2.12 (zip, 17MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.20.zip)

--- a/doc/internals/version-history.md
+++ b/doc/internals/version-history.md
@@ -5,6 +5,7 @@ title: Version history
 
 ## Version history of Scala.js
 
+- [0.6.21](/news/2017/11/06/announcing-scalajs-0.6.21/)
 - [0.6.20](/news/2017/09/01/announcing-scalajs-0.6.20/)
 - [0.6.19](/news/2017/07/29/announcing-scalajs-0.6.19/)
 - [1.0.0-M1](/news/2017/07/03/announcing-scalajs-1.0.0-M1/)


### PR DESCRIPTION
TBA tomorrow (Saturday) sometime during the day.