### PR TITLE
Announcing Scala.js 0.6.22.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ colors:  #in hex code if not noted else
 
 ### VERSIONS ###
 versions:
-  scalaJS: 0.6.21
+  scalaJS: 0.6.22
   scalaJSBinary: 0.6
   scalaJSDev: 1.0.0-M2
   scalaJSDevBinary: 1.0.0-M2

--- a/_posts/news/2018-01-24-announcing-scalajs-0.6.22.md
+++ b/_posts/news/2018-01-24-announcing-scalajs-0.6.22.md
@@ -1,0 +1,51 @@
+---
+layout: post
+title: Announcing Scala.js 0.6.22
+category: news
+tags: [releases]
+permalink: /news/2018/01/24/announcing-scalajs-0.6.22/
+---
+
+
+We are pleased to announce the release of Scala.js 0.6.22!
+
+This release is almost exclusively a bug-fix release.
+It also features an improvement in terms of memory consumption and execution performance while running tests.
+
+Read on for more details.
+
+<!--more-->
+
+## Getting started
+
+If you are new to Scala.js, head over to
+[the tutorial]({{ BASE_PATH }}/tutorial/).
+
+## Release notes
+
+If upgrading from Scala.js 0.6.14 or earlier, make sure to read [the release notes of 0.6.15]({{ BASE_PATH }}/news/2017/03/21/announcing-scalajs-0.6.15/), which contain important migration information.
+
+As a minor release, 0.6.22 is backward source and binary compatible with previous releases in the 0.6.x series.
+Libraries compiled with earlier versions can be used with 0.6.22 without change.
+0.6.22 is also forward binary compatible with 0.6.{17-21}, but not with earlier releases: libraries compiled with 0.6.22 cannot be used by projects using 0.6.{0-16}.
+
+Please report any issues [on GitHub](https://github.com/scala-js/scala-js/issues).
+
+## New features
+
+### JDK APIs
+
+The following JDK API methods have been added:
+
+* `java.nio.Charset.aliases()`
+
+## Bug fixes
+
+Among others, the following bugs have been fixed in 0.6.22:
+
+* [#3206](https://github.com/scala-js/scala-js/issues/3206) Standard error of Scala.js is erroneously sent to `logger.error`, instead of to stderr
+* [#3218](https://github.com/scala-js/scala-js/issues/3218) main() in test scope is executed twice when using test framework and a main module initializer in Test
+* [#3219](https://github.com/scala-js/scala-js/issues/3219) Methods exported under a scalac name starting with `$` are not exported
+* [#3264](https://github.com/scala-js/scala-js/issues/3264) NPE while compiling an LMF-capable SAM inside an anonymous JS class
+
+You can find the full list [on GitHub](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av0.6.22+is%3Aclosed).

--- a/doc/all-api.md
+++ b/doc/all-api.md
@@ -5,6 +5,17 @@ title: All previous versions of the Scala.js API
 
 ## All previous versions of the API
 
+### Scala.js 0.6.22
+* [0.6.22 scalajs-library]({{ site.production_url }}/api/scalajs-library/0.6.22/#scala.scalajs.js.package)
+* [0.6.22 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/0.6.22/)
+* [0.6.22 scalajs-stubs]({{ site.production_url }}/api/scalajs-stubs/0.6.22/)
+* [0.6.22 scalajs-ir]({{ site.production_url }}/api/scalajs-ir/0.6.22/#org.scalajs.core.ir.package)
+* [0.6.22 scalajs-tools]({{ site.production_url }}/api/scalajs-tools/0.6.22/#org.scalajs.core.tools.package) ([Scala.js version]({{ site.production_url }}/api/scalajs-tools-js/0.6.22/#org.scalajs.core.tools.package))
+* [0.6.22 scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/0.6.22/#org.scalajs.jsenv.package)
+* [0.6.22 scalajs-js-envs-test-kit]({{ site.production_url }}/api/scalajs-js-envs-test-kit/0.6.22/#org.scalajs.jsenv.test.package)
+* [0.6.22 scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/0.6.22/#org.scalajs.testadapter.package)
+* [0.6.22 sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/0.6.22/#org.scalajs.sbtplugin.package)
+
 ### Scala.js 1.0.0-M2
 * [1.0.0-M2 scalajs-library]({{ site.production_url }}/api/scalajs-library/1.0.0-M2/scala/scalajs/js/index.html)
 * [1.0.0-M2 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/1.0.0-M2/)

--- a/doc/internals/downloads.md
+++ b/doc/internals/downloads.md
@@ -7,6 +7,14 @@ We strongly recommend using the SBT plugin, as shown in the [bootstrapping skele
 
 The CLI distribution requires `scala` and `scalac` (of the right major version) to be on the execution path. Unpack it wherever you like and add the `bin/` folder to your execution path.
 
+#### Scala.js 0.6.22
+* [0.6.22, Scala 2.12 (tgz, 18MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.22.tgz)
+* [0.6.22, Scala 2.12 (zip, 18MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.22.zip)
+* [0.6.22, Scala 2.11 (tgz, 30MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.22.tgz)
+* [0.6.22, Scala 2.11 (zip, 30MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.22.zip)
+* [0.6.22, Scala 2.10 (tgz, 25MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.22.tgz)
+* [0.6.22, Scala 2.10 (zip, 25MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.22.zip)
+
 #### Scala.js 1.0.0-M2
 * [1.0.0-M2, Scala 2.12 (tgz, 16MB)]({{ site.production_url }}/files/scalajs_2.12-1.0.0-M2.tgz)
 * [1.0.0-M2, Scala 2.12 (zip, 16MB)]({{ site.production_url }}/files/scalajs_2.12-1.0.0-M2.zip)

--- a/doc/internals/version-history.md
+++ b/doc/internals/version-history.md
@@ -5,6 +5,7 @@ title: Version history
 
 ## Version history of Scala.js
 
+- [0.6.22](/news/2018/01/24/announcing-scalajs-0.6.22/)
 - [1.0.0-M2](/news/2017/11/29/announcing-scalajs-1.0.0-M2/)
 - [0.6.21](/news/2017/11/06/announcing-scalajs-0.6.21/)
 - [0.6.20](/news/2017/09/01/announcing-scalajs-0.6.20/)


### PR DESCRIPTION
To be announced sometime tomorrow January 24.