### PR TITLE
Fix #394: clarify sbt plugins for cross-project builds

### DIFF
--- a/doc/project/cross-build.md
+++ b/doc/project/cross-build.md
@@ -60,6 +60,8 @@ lazy val fooJVM = foo.jvm
 lazy val fooJS = foo.js
 {% endhighlight %}
 
+Note that `enablePlugins(ScalaJSPlugin)` **must not** be included when using `crossProject`.
+
 You now have separate projects to compile towards Scala.js and Scala JVM. Note the same name given to both projects, this allows them to be published with corresponding artifact names:
 
 - `foo_2.11-0.1-SNAPSHOT.jar`


### PR DESCRIPTION
I was confused about why a cross-project build was packaging SJSIR JARs for my JVM project until I realized that I should not include `enablePlugins(ScalaJSPlugin)` on my cross project build. Hopefully adding this line to the documentation to make it more clear saves someone else some time. (Fixes #394, which I just discovered!) 