### PR TITLE
Use jquery-facade instead of scalajs-jquery in the tutorial.

### DIFF
--- a/_data/library/jsfacades.yml
+++ b/_data/library/jsfacades.yml
@@ -3,15 +3,11 @@
     - name: scala-js-dom
       url: https://github.com/scala-js/scala-js-dom
       desc: Static types for the DOM API, plus a few extensions
-      dep: '"org.scala-js" %%% "scalajs-dom" % "0.9.0"'
-    - name: scalajs-jquery
-      url: https://github.com/scala-js/scala-js-jquery
-      desc: Static types for jQuery
-      dep: '"be.doeraene" %%% "scalajs-jquery" % "0.9.0"'
+      dep: '"org.scala-js" %%% "scalajs-dom" % "0.9.5"'
     - name: jquery-facade
       url: https://github.com/jducoeur/jquery-facade
-      desc: Alternate, more strongly-typed static types for jQuery
-      dep: '"org.querki" %%% "jquery-facade" % "1.0-RC6"'
+      desc: A strongly-typed Scala.js facade for jQuery
+      dep: '"org.querki" %%% "jquery-facade" % "1.2"'
     - name: udash-jquery
       url: https://github.com/UdashFramework/scala-js-jquery
       desc: Alternate strongly typed facade for jQuery


### PR DESCRIPTION
We keep telling people that jquery-facade is better maintained than scalajs-jquery and is the recommended library for jQuery, but our tutorial was still using scalajs-jquery, setting users on the wrong path.

In the process, we also upgrade to the latest versions of scalajs-dom and uTest.

The PR also removes scalajs-jquery from the list of facade libraries.

The updated tutorial repo can be seen in [the `develop` branch](https://github.com/scala-js/scalajs-tutorial/commits/develop), for review.