### PR TITLE
fixed double title in news

### DIFF
--- a/_includes/wrap.html
+++ b/_includes/wrap.html
@@ -1,7 +1,7 @@
 <div id="blue">
     <div class="container">
         <div class="row">
-            <h3>{% if page.wrap_title %}{{ page.wrap_title }}{% else %}{{ page.title }}{% endif %}</h3>
+            <h3>{% if layout.wrap_title %}{{ layout.wrap_title }}{% else %}{{ page.title }}{% endif %}</h3>
         </div><!-- /row -->
     </div> <!-- /container -->
 </div><!-- /blue -->


### PR DESCRIPTION
When going on a *News* in the scala-js website, the title of the news appears twice. Once within the top blue band beneath the navbar, and then another one within the content.

Given what the `_includes/wrap.html` file contains, I figured that it was not the behaviour intended. What's actually intended seems to be that the blue bar should contain "News". This is fixed by changing `page.wrap_title` by `layout.wrap_title` in the Liquid variables.

Perhaps you should check that it then actually does what you're looking for.