### PR TITLE
Fix the computation of `bestScore` in an example.

### DIFF
--- a/doc/sjs-for-js/es6-to-scala-part2.md
+++ b/doc/sjs-for-js/es6-to-scala-part2.md
@@ -384,7 +384,7 @@ def addScore(player: String, score: Int): Unit = {
 }
 
 def bestScore: (String, Int) = {
-  val all = scores.flatMap {
+  val all = scores.toList.flatMap {
     case (player, pScores) =>
       pScores.map(s => (player, s))
   }


### PR DESCRIPTION
The code in the example doesn't work since `Map.flatMap` returns a `Map` (on a tuple with 2 elements) so only the last score will be taken into consideration. The code below will return `("Jane", 200)` but it should be `("John", 1000)`

Making the flatMap return a list will return the list of tuple scores as intended.

```
val scores =
    mutable.Map.empty[String, mutable.Buffer[Int]]

  def addScore(player: String, score: Int): Unit = {
    scores.getOrElseUpdate(player, mutable.Buffer())
      .append(score)
  }

  def bestScore: (String, Int) = {
    val all = scores.flatMap {
      case (player, pScores) =>
        pScores.map(s => (player, s))
    }
    if (all.isEmpty)
      ("", 0)
    else
      all.maxBy(_._2)
  }

  def averageScore: Int = {
    val allScores = scores.flatMap(_._2)
    if (allScores.isEmpty)
      0
    else
      allScores.sum / allScores.size
  }

  addScore("John", 1000)
  addScore("John", 100)
  addScore("Jane", 200)

  println(bestScore)
  println(averageScore)
```