### PR TITLE
Update Interoperability/index.md

### DIFF
--- a/doc/interoperability/index.md
+++ b/doc/interoperability/index.md
@@ -33,13 +33,13 @@ xhr.send();
 
 {% column 6 Scala.js %}
 {% highlight scala %}
-val xhr = new XMLHttpRequest()
+var xhr = new XMLHttpRequest()
 
 xhr.open("GET",
   "https://api.twitter.com/1.1/search/" +
   "tweets.json?q=%23scalajs"
 )
-xhr.onload = { (e: Event) =>
+xhr.onload = (e: Event) => {
   if (xhr.status == 200) {
     val r = JSON.parse(xhr.responseText)
     $("#tweets").html(parseTweets(r))


### PR DESCRIPTION
* The equivalent of `var` in JS is `var` in Scala. The equivalent of `val` in Scala is `const` in JS. They should be consistent: either use `var` for both, or use `const` and `val` (IMO in order to show similarity, using var is probably better)
* Move the curly brace as style change to match JS code.