### PR TITLE
Add JUnit to supported testing libs

### DIFF
--- a/_data/library/testlibs.yml
+++ b/_data/library/testlibs.yml
@@ -1,7 +1,7 @@
 - topic: Test frameworks
   libraries:
     - name: JUnit
-      url: https://junit.org/junit5/
+      url: https://junit.org/junit4/
       desc: A programmer-friendly Java testing framework
       dep: 'enablePlugins(ScalaJSJUnitPlugin)'
     - name: uTest

--- a/_data/library/testlibs.yml
+++ b/_data/library/testlibs.yml
@@ -1,5 +1,9 @@
 - topic: Test frameworks
   libraries:
+    - name: JUnit
+      url: https://junit.org/junit5/
+      desc: A programmer-friendly Java testing framework
+      dep: 'enablePlugins(ScalaJSJUnitPlugin)'
     - name: uTest
       url: https://github.com/lihaoyi/utest
       desc: Simple testing framework with good Scala.js support


### PR DESCRIPTION
I added the `enablePlugins` incantation to add support for the library in sbt, as the rest of dependencies assume sbt too.
  
Followed the instructions in https://www.scala-js.org/news/2016/01/25/announcing-scalajs-0.6.6/