### PR TITLE
Announcing Scala.js 0.6.26.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ colors:  #in hex code if not noted else
 
 ### VERSIONS ###
 versions:
-  scalaJS: 0.6.25
+  scalaJS: 0.6.26
   scalaJSBinary: 0.6
   scalaJSDev: 1.0.0-M6
   scalaJSDevBinary: 1.0.0-M6

--- a/_posts/news/2018-11-29-announcing-scalajs-0.6.26.md
+++ b/_posts/news/2018-11-29-announcing-scalajs-0.6.26.md
@@ -1,0 +1,179 @@
+---
+layout: post
+title: Announcing Scala.js 0.6.26
+category: news
+tags: [releases]
+permalink: /news/2018/11/29/announcing-scalajs-0.6.26/
+---
+
+
+We are pleased to announce the release of Scala.js 0.6.26!
+
+The highlight of this release is the support for ECMAScript modules.
+It also fixes a few issues.
+
+Starting from 0.6.26 in the 0.6.x branch, Scala.js has been relicensed under the Apache License 2.0, following the corresponding relicensing of Scala upstream.
+Scala.js 1.x milestones have also been relicensed since version 1.0.0-M6.
+
+Read on for more details.
+
+<!--more-->
+
+## Getting started
+
+If you are new to Scala.js, head over to
+[the tutorial]({{ BASE_PATH }}/tutorial/).
+
+## Release notes
+
+If you use `.scala` build files in `project/` and are upgrading from Scala.js 0.6.22 or earlier, do read [the release notes of 0.6.23]({{ BASE_PATH }}/news/2018/05/22/announcing-scalajs-0.6.23/), which contain a source breaking change in that situation.
+
+If upgrading from Scala.js 0.6.14 or earlier, make sure to read [the release notes of 0.6.15]({{ BASE_PATH }}/news/2017/03/21/announcing-scalajs-0.6.15/), which contain important migration information.
+
+As a minor release, 0.6.26 is backward binary compatible with previous releases in the 0.6.x series.
+Libraries compiled with earlier versions can be used with 0.6.26 without change.
+0.6.26 is also forward binary compatible with 0.6.{17-25}, but not with earlier releases: libraries compiled with 0.6.26 cannot be used by projects using 0.6.{0-16}.
+
+Please report any issues [on GitHub](https://github.com/scala-js/scala-js/issues).
+
+## Top-level exports with namespaces are deprecated
+
+Top-level exports with namespaces, such as
+
+{% highlight scala %}
+@JSExportTopLevel("foo.Bar")
+object Bar
+{% endhighlight %}
+
+are deprecated, as they do not have a good equivalent in ECMAScript modules.
+
+If necessary, you can use the following idiom instead:
+
+{% highlight scala %}
+package mypack
+
+// not directly exported
+object Bar
+
+object TopLevelExports {
+  @JSExportTopLevel("foo")
+  val foo = new js.Object {
+    val Bar = mypack.Bar
+  }
+}
+{% endhighlight %}
+
+The deprecation warning can be silenced in the 0.6.x series with
+
+{% highlight scala %}
+scalacOptions += "-P:scalajs:suppressExportDeprecations"
+{% endhighlight %}
+
+## Support for ECMAScript modules
+
+Scala.js can now emit a project as an ECMAScript module, in addition to a script or a CommonJS module.
+This can be enabled with
+
+{% highlight scala %}
+scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) }
+{% endhighlight %}
+
+In that case, `@JSImport` and `@JSExportTopLevel` will straightforwardly map to ECMAScript `import` and `export` statements:
+
+{% columns %}
+{% column 6 Scala.js %}
+{% highlight scala %}
+@JSExportTopLevel("foo")
+object Bar
+{% endhighlight %}
+{% endcolumn %}
+
+{% column 6 ECMAScript %}
+{% highlight javascript %}
+export { Bar as foo }
+{% endhighlight %}
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column 6 Scala.js %}
+{% highlight scala %}
+@js.native
+@JSImport("mod.js", "foo")
+object Bar extends js.Object
+{% endhighlight %}
+{% endcolumn %}
+
+{% column 6 ECMAScript %}
+{% highlight javascript %}
+import { foo as Bar } from "mod.js"
+{% endhighlight %}
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column 6 Scala.js %}
+{% highlight scala %}
+@js.native
+@JSImport("mod.js", JSImport.Namespace)
+object Bar extends js.Object
+{% endhighlight %}
+{% endcolumn %}
+
+{% column 6 ECMAScript %}
+{% highlight javascript %}
+import * as Bar from "mod.js"
+{% endhighlight %}
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column 6 Scala.js %}
+{% highlight scala %}
+@js.native
+@JSImport("mod.js", JSImport.Default)
+object Bar extends js.Object
+{% endhighlight %}
+{% endcolumn %}
+
+{% column 6 ECMAScript %}
+{% highlight javascript %}
+import Bar from "mod.js"
+{% endhighlight %}
+{% endcolumn %}
+{% endcolumns %}
+
+To run and test such a project, Node.js v10.2.0 or later is required.
+We recommend v10.12.0 or later, as it is the version that we continuously test.
+In addition, you will need a few additional settings:
+
+{% highlight scala %}
+jsEnv := {
+  new org.scalajs.jsenv.NodeJSEnv(
+      org.scalajs.jsenv.NODEJSEnv.Config()
+        .withArguments(List("--experimental-modules"))
+  )
+}
+
+artifactPath in (proj, Compile, fastOptJS) :=
+  (crossTarget in (proj, Compile)).value / "myproject.mjs"
+
+artifactPath in (proj, Test, fastOptJS) :=
+  (crossTarget in (proj, Test)).value / "myproject-test.mjs"
+{% endhighlight %}
+
+The first setting is required to enable the support of ES modules in Node.js.
+The other two make sure that the JavaScript produced have the extension `.mjs`, which is required for Node.js to interpret them as ES modules.
+
+The support for running and testing ES modules with Node.js is *experimental*, as the support of ES modules by Node.js is itself experimental.
+Things could change in future versions of Node.js and/or Scala.js.
+
+## Bug fixes
+
+Among others, the following bugs have been fixed in 0.6.26:
+
+* [#3445](https://github.com/scala-js/scala-js/issues/3445) Linking error on `Array()` pattern with Scala.js 0.6.25 and Scala 2.13.0-M4
+* [#3280](https://github.com/scala-js/scala-js/issues/3280) Matcher.groupCount behaviour inconsistent between JS and JVM
+* [#3492](https://github.com/scala-js/scala-js/issues/3492) Double underscore `__` should not be forbidden in top-level exports
+
+You can find the full list [on GitHub](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av0.6.25+is%3Aclosed).

--- a/doc/all-api.md
+++ b/doc/all-api.md
@@ -5,6 +5,17 @@ title: All previous versions of the Scala.js API
 
 ## All previous versions of the API
 
+### Scala.js 0.6.26
+* [0.6.26 scalajs-library]({{ site.production_url }}/api/scalajs-library/0.6.26/#scala.scalajs.js.package)
+* [0.6.26 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/0.6.26/)
+* [0.6.26 scalajs-stubs]({{ site.production_url }}/api/scalajs-stubs/0.6.26/)
+* [0.6.26 scalajs-ir]({{ site.production_url }}/api/scalajs-ir/0.6.26/#org.scalajs.core.ir.package)
+* [0.6.26 scalajs-tools]({{ site.production_url }}/api/scalajs-tools/0.6.26/#org.scalajs.core.tools.package) ([Scala.js version]({{ site.production_url }}/api/scalajs-tools-js/0.6.26/#org.scalajs.core.tools.package))
+* [0.6.26 scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/0.6.26/#org.scalajs.jsenv.package)
+* [0.6.26 scalajs-js-envs-test-kit]({{ site.production_url }}/api/scalajs-js-envs-test-kit/0.6.26/#org.scalajs.jsenv.test.package)
+* [0.6.26 scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/0.6.26/#org.scalajs.testadapter.package)
+* [0.6.26 sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/0.6.26/#org.scalajs.sbtplugin.package)
+
 ### Scala.js 1.0.0-M6
 * [1.0.0-M6 scalajs-library]({{ site.production_url }}/api/scalajs-library/1.0.0-M6/scala/scalajs/js/index.html)
 * [1.0.0-M6 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/1.0.0-M6/)

--- a/doc/internals/downloads.md
+++ b/doc/internals/downloads.md
@@ -7,6 +7,14 @@ We strongly recommend using the SBT plugin, as shown in the [bootstrapping skele
 
 The CLI distribution requires `scala` and `scalac` (of the right major version) to be on the execution path. Unpack it wherever you like and add the `bin/` folder to your execution path.
 
+#### Scala.js 0.6.26
+* [0.6.26, Scala 2.12 (tgz, 20MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.26.tgz)
+* [0.6.26, Scala 2.12 (zip, 20MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.26.zip)
+* [0.6.26, Scala 2.11 (tgz, 30MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.26.tgz)
+* [0.6.26, Scala 2.11 (zip, 30MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.26.zip)
+* [0.6.26, Scala 2.10 (tgz, 25MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.26.tgz)
+* [0.6.26, Scala 2.10 (zip, 25MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.26.zip)
+
 #### Scala.js 1.0.0-M6
 * [1.0.0-M6, Scala 2.12 (tgz, 18MB)]({{ site.production_url }}/files/scalajs_2.12-1.0.0-M6.tgz)
 * [1.0.0-M6, Scala 2.12 (zip, 18MB)]({{ site.production_url }}/files/scalajs_2.12-1.0.0-M6.zip)

--- a/doc/internals/version-history.md
+++ b/doc/internals/version-history.md
@@ -5,6 +5,7 @@ title: Version history
 
 ## Version history of Scala.js
 
+- [0.6.26](/news/2018/11/29/announcing-scalajs-0.6.26/)
 - [1.0.0-M6](/news/2018/10/24/announcing-scalajs-1.0.0-M6/)
 - [0.6.25](/news/2018/09/03/announcing-scalajs-0.6.25/)
 - [1.0.0-M5](/news/2018/08/13/announcing-scalajs-1.0.0-M5/)

--- a/doc/interoperability/export-to-javascript.md
+++ b/doc/interoperability/export-to-javascript.md
@@ -55,8 +55,16 @@ object HelloWorld {
 
 exports the `HelloWorld` object in JavaScript.
 
-The name can contain dots, in which case the exported object is namespaced in
-JavaScript.
+**Pre 0.6.15 note**: Before Scala.js 0.6.15, objects were exported as 0-argument
+functions using `@JSExport`, rather than directly with `@JSExportTopLevel`. This
+is deprecated in 0.6.x, and not supported anymore in Scala.js 1.x.
+
+### Exporting under a namespace (deprecated)
+
+**Note:** Deprecated since Scala.js 0.6.26, and not supported anymore in Scala.js 1.x.
+
+The export name can contain dots, in which case the exported object is namespaced in JavaScript.
+For example,
 
 {% highlight scala %}
 @JSExportTopLevel("myapp.foo.MainObject")
@@ -66,10 +74,6 @@ object HelloWorld {
 {% endhighlight %}
 
 will be accessible in JavaScript using `myapp.foo.MainObject`.
-
-**Pre 0.6.15 note**: Before Scala.js 0.6.15, objects were exported as 0-argument
-functions using `@JSExport`, rather than directly with `@JSExportTopLevel`. This
-is deprecated in 0.6.x, and not supported anymore in Scala.js 1.x.
 
 ## Exporting classes
 
@@ -94,9 +98,6 @@ console.log(foo.toString());
 will log the string `"Foo(3)"` to the console. This particular example works
 because it calls `toString()`, which is always exported to JavaScript. Other
 methods must be exported explicitly as shown in the next section.
-
-As is the case for top-level objects, classes can be exported under a namespace,
-by using dots in the argument to `@JSExportTopLevel`.
 
 **Pre 0.6.15 note**: Before Scala.js 0.6.15, classes were exported using
 `@JSExport` instead of `@JSExportTopLevel`, with the same meaning. This is

--- a/doc/project/module.md
+++ b/doc/project/module.md
@@ -6,9 +6,14 @@ title: Emitting a JavaScript module
 By default, the `-fastopt.js` and `-fullopt.js` files produced by Scala.js are top-level *scripts*, and their `@JSExport`ed stuff are sent to the global scope.
 With modern JavaScript toolchains, we typically write *modules* instead, which import and export things from other modules.
 You can configure Scala.js to emit a JavaScript module instead of a top-level script.
-Currently, only the CommonJS module format is supported, with the following sbt setting:
+
+Two kinds of modules are supported: CommonJS modules (traditional module system of Node.js) and ECMAScript modules.
+They are enabled with the following sbt settings:
 
 {% highlight scala %}
+// ECMAScript
+scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) }
+// CommonJS
 scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
 {% endhighlight %}
 
@@ -37,7 +42,26 @@ class Foobaz(x: String) extends js.Object {
 }
 {% endhighlight %}
 
-Once compiled under `ModuleKind.CommonJSModule`, the resulting module would be equivalent to the following JavaScript module:
+Once compiled under `ModuleKind.ESModule`, the resulting module would be equivalent to the following JavaScript module:
+
+{% highlight javascript %}
+import { Foo as JSFoo } from "bar.js";
+
+class Foobaz {
+  constructor(x) {
+    this.x = x;
+    this.inner = new JSFoo(x.length);
+  }
+
+  method(y) {
+    return this.x + y;
+  }
+}
+
+export { Foobaz as Babar };
+{% endhighlight %}
+
+With `ModuleKind.CommonJSModule`, it would instead be equivalent to:
 
 {% highlight javascript %}
 var bar = require("bar.js");


### PR DESCRIPTION
And update the documentation for the support of ECMAScript modules.