### PR TITLE
Fix the double title in News page.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,11 +7,7 @@ wrap_title: News
 
 <div class="container mtb">
     <div class="row">
-        <! -- SINGLE POST -->
         <div class="col-md-12">
-            <! -- Blog Post -->
-            <a href="{{ page.url | prepend: site.baseurl }}"><h3 class="ctitle">{{ page.title }}</h3></a>
-
             <p>
                 <span class="small">{{ page.date | date: "%b %-d, %Y" }}.</span>
             </p>


### PR DESCRIPTION
The page title is already inserted by `wrap.html`. It shouldn't be repeated in the `post` layout.