### PR TITLE
Fix the signature of `def parse` in an example.

### DIFF
--- a/doc/sjs-for-js/es6-to-scala-part3.md
+++ b/doc/sjs-for-js/es6-to-scala-part3.md
@@ -81,7 +81,7 @@ const r = parse("JB/007", '/');
 
 {% column 6 Scala %}
 {% highlight scala %}
-def parse(str: String, magicKey: Char): String = {
+def parse(str: String, magicKey: Char): Seq[String] = {
   str.map {
     case c if c == magicKey =>
       "magic"


### PR DESCRIPTION
self explanatory the current signature doesn't work.