### PR TITLE
Announcing Scala.js 0.6.31.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ colors:  #in hex code if not noted else
 
 ### VERSIONS ###
 versions:
-  scalaJS: 0.6.29
+  scalaJS: 0.6.31
   scalaJSBinary: 0.6
   scalaJSDev: 1.0.0-M8
   scalaJSDevBinary: 1.0.0-M8

--- a/_posts/news/2019-11-21-announcing-scalajs-0.6.31.md
+++ b/_posts/news/2019-11-21-announcing-scalajs-0.6.31.md
@@ -1,0 +1,83 @@
+---
+layout: post
+title: Announcing Scala.js 0.6.31
+category: news
+tags: [releases]
+permalink: /news/2019/11/21/announcing-scalajs-0.6.31/
+---
+
+
+We are pleased to announce the release of Scala.js 0.6.31!
+
+This release upgrades the version of the Scala standard library to 2.12.10 and 2.13.1.
+The upgrade to 2.13.1 notably fixed a number of issues.
+The release also contains the definitions for `BigInt` and its typed arrays `BigInt64Array` and `BigUint64Array`, thanks to [@exoego](https://github.com/exoego), as well as the implementation of `java.util.IdentityHashMap`, thanks to [@ekrich](https://github.com/ekrich).
+
+If you are wondering where v0.6.30 went, it was [severely broken](https://github.com/scala-js/scala-js/issues/3865) and hence was never announced.
+
+Read on for more details.
+
+<!--more-->
+
+## Getting started
+
+If you are new to Scala.js, head over to
+[the tutorial]({{ BASE_PATH }}/tutorial/).
+
+## Release notes
+
+If you use `.scala` build files in `project/` and are upgrading from Scala.js 0.6.22 or earlier, do read [the release notes of 0.6.23]({{ BASE_PATH }}/news/2018/05/22/announcing-scalajs-0.6.23/), which contain a source breaking change in that situation.
+
+If upgrading from Scala.js 0.6.14 or earlier, make sure to read [the release notes of 0.6.15]({{ BASE_PATH }}/news/2017/03/21/announcing-scalajs-0.6.15/), which contain important migration information.
+
+As a minor release, 0.6.31 is backward binary compatible with previous releases in the 0.6.x series.
+Libraries compiled with earlier versions can be used with 0.6.31 without change.
+0.6.31 is also forward binary compatible with 0.6.29, but not with earlier releases: libraries compiled with 0.6.31 cannot be used by projects using 0.6.{0-28} (nor from the broken 0.6.30).
+
+Please report any issues [on GitHub](https://github.com/scala-js/scala-js/issues).
+
+## Add `js.BigInt` and its typed arrays
+
+`BigInt`s have made it to Stage 4 of the ECMAScript language evolution process, which means that they are now standard, and will be part of ECMAScript 2020.
+[@exoego](https://github.com/exoego) contributed type definitions in the Scala.js standard library to be able to manipulate them.
+As a simple example:
+
+{% highlight scala %}
+import scala.scalajs.js
+
+def fact(n: js.BigInt): js.BigInt =
+  if (n == js.BigInt(0)) js.BigInt(1)
+  else n * fact(n - js.BigInt(1))
+
+println(fact(js.BigInt(30)))
+// prints: 265252859812191058636308480000000
+{% endhighlight %}
+
+Successfully running this program will require a recent version of Node.js.
+
+The definitions for `BigInt64Array` and `BigUint64Array` are also available, in the package `scala.scalajs.js.typedarray`.
+
+## Miscellaneous
+
+### New JDK APIs
+
+The class `java.util.IdentityHashMap` is now available, thanks to a contribution by [@ekrich](https://github.com/ekrich).
+
+### Add `js.special.strictEquals` to perform JavaScript's `===`
+
+You can now use `js.special.strictEquals(x, y)` to perform exactly the same operation as JavaScript's `x === y`, known as *strict equality*.
+In Scala.js 0.6.x, `x eq y` is equivalent, but in Scala.js 1.x, `x eq y` will be stricter to better match Scala/JVM: it will consider `+0` and `-0` as different, but `NaN` equal to itself.
+
+Using `js.special.strictEquals` should be rare.
+Usually `eq` does the right thing.
+
+## Bug fixes
+
+Among others, the following bugs have been fixed in 0.6.31:
+
+* [#3865](https://github.com/scala-js/scala-js/issues/3865) Scala.js 0.6.30 does not acknowledge IR version 0.6.29 as supported.
+* [#3778](https://github.com/scala-js/scala-js/issues/3778) Using `ListBuffer.clone()` breaks `Vector` with Scala 2.13
+* [#3808](https://github.com/scala-js/scala-js/issues/3808) `Seq.unapplySeq(LazyList.from(0)).drop(1)` causes infinite loop (upstream bug fixed in 2.13.1)
+* [#3848](https://github.com/scala-js/scala-js/issues/3848) `FunctionEmitter` incorrectly classifies `ArraySelect` as side-effect free
+
+You can find the full list on GitHub for [issues fixed in 0.6.30](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av0.6.30+is%3Aclosed) and [issues fixed in 0.6.31](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av0.6.31+is%3Aclosed).

--- a/doc/all-api.md
+++ b/doc/all-api.md
@@ -5,6 +5,19 @@ title: All previous versions of the Scala.js API
 
 ## All previous versions of the API
 
+### Scala.js 0.6.31
+* [0.6.31 scalajs-library]({{ site.production_url }}/api/scalajs-library/0.6.31/#scala.scalajs.js.package)
+* [0.6.31 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/0.6.31/)
+* [0.6.31 scalajs-stubs]({{ site.production_url }}/api/scalajs-stubs/0.6.31/)
+* [0.6.31 scalajs-ir]({{ site.production_url }}/api/scalajs-ir/0.6.31/#org.scalajs.core.ir.package)
+* [0.6.31 scalajs-tools]({{ site.production_url }}/api/scalajs-tools/0.6.31/#org.scalajs.core.tools.package) ([Scala.js version]({{ site.production_url }}/api/scalajs-tools-js/0.6.31/#org.scalajs.core.tools.package))
+* [0.6.31 scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/0.6.31/#org.scalajs.jsenv.package)
+* [0.6.31 scalajs-js-envs-test-kit]({{ site.production_url }}/api/scalajs-js-envs-test-kit/0.6.31/#org.scalajs.jsenv.test.package)
+* [0.6.31 scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/0.6.31/#org.scalajs.testadapter.package)
+* [0.6.31 sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/0.6.31/#org.scalajs.sbtplugin.package)
+
+Scala.js 0.6.30 was [severely broken](https://github.com/scala-js/scala-js/issues/3865) and is therefore not listed here.
+
 ### Scala.js 0.6.29
 * [0.6.29 scalajs-library]({{ site.production_url }}/api/scalajs-library/0.6.29/#scala.scalajs.js.package)
 * [0.6.29 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/0.6.29/)

--- a/doc/internals/downloads.md
+++ b/doc/internals/downloads.md
@@ -7,6 +7,18 @@ We strongly recommend using the SBT plugin, as shown in the [bootstrapping skele
 
 The CLI distribution requires `scala` and `scalac` (of the right major version) to be on the execution path. Unpack it wherever you like and add the `bin/` folder to your execution path.
 
+#### Scala.js 0.6.31
+* [0.6.31, Scala 2.13 (tgz, 22MB)]({{ site.production_url }}/files/scalajs_2.13-0.6.31.tgz)
+* [0.6.31, Scala 2.13 (zip, 22MB)]({{ site.production_url }}/files/scalajs_2.13-0.6.31.zip)
+* [0.6.31, Scala 2.12 (tgz, 29MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.31.tgz)
+* [0.6.31, Scala 2.12 (zip, 29MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.31.zip)
+* [0.6.31, Scala 2.11 (tgz, 36MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.31.tgz)
+* [0.6.31, Scala 2.11 (zip, 36MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.31.zip)
+* [0.6.31, Scala 2.10 (tgz, 30MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.31.tgz)
+* [0.6.31, Scala 2.10 (zip, 30MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.31.zip)
+
+Scala.js 0.6.30 was [severely broken](https://github.com/scala-js/scala-js/issues/3865) and is therefore not listed here.
+
 #### Scala.js 0.6.29
 * [0.6.29, Scala 2.12 (tgz, 27MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.29.tgz)
 * [0.6.29, Scala 2.12 (zip, 27MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.29.zip)

--- a/doc/internals/version-history.md
+++ b/doc/internals/version-history.md
@@ -5,6 +5,8 @@ title: Version history
 
 ## Version history of Scala.js
 
+- [0.6.31](/news/2019/11/21/announcing-scalajs-0.6.31/)
+- ~~0.6.30~~ ([severely broken](https://github.com/scala-js/scala-js/issues/3865) and therefore never announced)
 - [0.6.29](/news/2019/09/18/announcing-scalajs-0.6.29/)
 - [1.0.0-M8](/news/2019/06/03/announcing-scalajs-1.0.0-M8/)
 - [0.6.28](/news/2019/05/24/announcing-scalajs-0.6.28/)


### PR DESCRIPTION
Replaces #460.