### PR TITLE
Add more documentation about using ES modules.

### DIFF
--- a/doc/interoperability/facade-types.md
+++ b/doc/interoperability/facade-types.md
@@ -355,6 +355,73 @@ This is subject to change in future versions of Scala.js, to better reflect the 
 You should use a separate mechanism to manage your JavaScript dependencies.
 Scala.js does not provide any facility to do so, at the moment.
 
+### Translating ES imports to Scala.js `@JSImport`
+
+When the documentation of a library specifies how to write ES `import`s to use it, use the following table to translate those into Scala.js `@JSImport`s:
+
+{% columns %}
+{% column 6 Scala.js %}
+{% highlight scala %}
+@JSExportTopLevel("foo")
+object Bar
+{% endhighlight %}
+{% endcolumn %}
+
+{% column 6 ECMAScript %}
+{% highlight javascript %}
+export { Bar as foo }
+{% endhighlight %}
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column 6 Scala.js %}
+{% highlight scala %}
+@js.native
+@JSImport("mod.js", "foo")
+object Bar extends js.Object
+{% endhighlight %}
+{% endcolumn %}
+
+{% column 6 ECMAScript %}
+{% highlight javascript %}
+import { foo as Bar } from "mod.js"
+{% endhighlight %}
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column 6 Scala.js %}
+{% highlight scala %}
+@js.native
+@JSImport("mod.js", JSImport.Namespace)
+object Bar extends js.Object
+{% endhighlight %}
+{% endcolumn %}
+
+{% column 6 ECMAScript %}
+{% highlight javascript %}
+import * as Bar from "mod.js"
+{% endhighlight %}
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column 6 Scala.js %}
+{% highlight scala %}
+@js.native
+@JSImport("mod.js", JSImport.Default)
+object Bar extends js.Object
+{% endhighlight %}
+{% endcolumn %}
+
+{% column 6 ECMAScript %}
+{% highlight javascript %}
+import Bar from "mod.js"
+{% endhighlight %}
+{% endcolumn %}
+{% endcolumns %}
+
 ### Default import or namespace import?
 
 The *default* export accessible with `JSImport.Default`, specified in terms of ECMAScript 2015 modules, is somewhat underspecified when it comes to CommonJS, at the moment.

--- a/doc/project/module.md
+++ b/doc/project/module.md
@@ -79,3 +79,29 @@ class Foobaz {
 
 exports.Babar = Foobaz;
 {% endhighlight %}
+
+## ES modules and Node.js
+
+Support for ECMAScript modules is [still experimental in Node.js](https://nodejs.org/api/esm.html).
+To run and test a Scala.js application or library using ES modules with Node.js, you will need the following additional settings:
+
+{% highlight scala %}
+jsEnv := {
+  new org.scalajs.jsenv.NodeJSEnv(
+      org.scalajs.jsenv.NODEJSEnv.Config()
+        .withArguments(List("--experimental-modules"))
+  )
+}
+
+artifactPath in (proj, Compile, fastOptJS) :=
+  (crossTarget in (proj, Compile)).value / "myproject.mjs"
+
+artifactPath in (proj, Test, fastOptJS) :=
+  (crossTarget in (proj, Test)).value / "myproject-test.mjs"
+{% endhighlight %}
+
+The first setting is required to enable the support of ES modules in Node.js.
+The other two make sure that the JavaScript produced have the extension `.mjs`, which is required for Node.js to interpret them as ES modules.
+
+The support for running and testing ES modules with Node.js is *experimental*, as the support of ES modules by Node.js is itself experimental.
+Things could change in future versions of Node.js and/or Scala.js.


### PR DESCRIPTION
The new documentation was copied from the release nodes of Scala.js 0.6.26.