### PR TITLE
Announcing Scala.js 0.6.32.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ colors:  #in hex code if not noted else
 
 ### VERSIONS ###
 versions:
-  scalaJS: 0.6.31
+  scalaJS: 0.6.32
   scalaJSBinary: 0.6
   scalaJSDev: 1.0.0-RC2
   scalaJSDevBinary: 1.0-RC2

--- a/_posts/news/2020-01-24-announcing-scalajs-0.6.32.md
+++ b/_posts/news/2020-01-24-announcing-scalajs-0.6.32.md
@@ -1,0 +1,51 @@
+---
+layout: post
+title: Announcing Scala.js 0.6.32
+category: news
+tags: [releases]
+permalink: /news/2020/01/24/announcing-scalajs-0.6.32/
+---
+
+
+We are pleased to announce the release of Scala.js 0.6.32!
+
+This is mostly a bugfix release, including a fix for a regression in regular expressions that appeared in 0.6.31 ([#3901](https://github.com/scala-js/scala-js/issues/3901)).
+This release also adds the definitions for some recent methods of `js.Object`, thanks to [@exoego](https://github.com/exoego), and the JDK interface `java.util.function.Consumer`, thanks to [mliarakos](https://github.com/mliarakos).
+
+Read on for more details.
+
+<!--more-->
+
+## Getting started
+
+If you are new to Scala.js, head over to
+[the tutorial]({{ BASE_PATH }}/tutorial/).
+
+## Release notes
+
+If you use `.scala` build files in `project/` and are upgrading from Scala.js 0.6.22 or earlier, do read [the release notes of 0.6.23]({{ BASE_PATH }}/news/2018/05/22/announcing-scalajs-0.6.23/), which contain a source breaking change in that situation.
+
+If upgrading from Scala.js 0.6.14 or earlier, make sure to read [the release notes of 0.6.15]({{ BASE_PATH }}/news/2017/03/21/announcing-scalajs-0.6.15/), which contain important migration information.
+
+As a minor release, 0.6.32 is backward binary compatible with previous releases in the 0.6.x series.
+Libraries compiled with earlier versions can be used with 0.6.32 without change.
+0.6.32 is also forward binary compatible with 0.6.{29-31}, but not with earlier releases: libraries compiled with 0.6.32 cannot be used by projects using 0.6.{0-28}.
+
+Please report any issues [on GitHub](https://github.com/scala-js/scala-js/issues).
+
+## Miscellaneous
+
+### New JDK APIs
+
+The interface `java.util.function.Consumer` is now available, thanks to a contribution by [mliarakos](https://github.com/mliarakos).
+
+## Bug fixes
+
+Among others, the following bugs have been fixed in 0.6.32:
+
+* [#3901](https://github.com/scala-js/scala-js/issues/3901) `TypeError` in regular expressions (regression from Scala.js 0.6.29)
+* [#3888](https://github.com/scala-js/scala-js/issues/3888) Linking errors on Scala 2.11 if an `object` is named `class`
+* [#3913](https://github.com/scala-js/scala-js/issues/3913) `java.io.ByteArrayInputStream` behaves differently between JS and JVM
+* [#3922](https://github.com/scala-js/scala-js/issues/3922) Wrong `maxBytesPerChar` for `CharsetEncoder`
+
+You can find the full list [on GitHub](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av0.6.32+is%3Aclosed).

--- a/doc/all-api.md
+++ b/doc/all-api.md
@@ -5,6 +5,17 @@ title: All previous versions of the Scala.js API
 
 ## All previous versions of the API
 
+### Scala.js 0.6.32
+* [0.6.32 scalajs-library]({{ site.production_url }}/api/scalajs-library/0.6.32/#scala.scalajs.js.package)
+* [0.6.32 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/0.6.32/)
+* [0.6.32 scalajs-stubs]({{ site.production_url }}/api/scalajs-stubs/0.6.32/)
+* [0.6.32 scalajs-ir]({{ site.production_url }}/api/scalajs-ir/0.6.32/#org.scalajs.core.ir.package)
+* [0.6.32 scalajs-tools]({{ site.production_url }}/api/scalajs-tools/0.6.32/#org.scalajs.core.tools.package) ([Scala.js version]({{ site.production_url }}/api/scalajs-tools-js/0.6.32/#org.scalajs.core.tools.package))
+* [0.6.32 scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/0.6.32/#org.scalajs.jsenv.package)
+* [0.6.32 scalajs-js-envs-test-kit]({{ site.production_url }}/api/scalajs-js-envs-test-kit/0.6.32/#org.scalajs.jsenv.test.package)
+* [0.6.32 scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/0.6.32/#org.scalajs.testadapter.package)
+* [0.6.32 sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/0.6.32/#org.scalajs.sbtplugin.package)
+
 ### Scala.js 1.0.0-RC2
 * [1.0.0-RC2 scalajs-library]({{ site.production_url }}/api/scalajs-library/1.0.0-RC2/scala/scalajs/js/index.html)
 * [1.0.0-RC2 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/1.0.0-RC2/)

--- a/doc/internals/downloads.md
+++ b/doc/internals/downloads.md
@@ -7,6 +7,16 @@ We strongly recommend using the SBT plugin, as shown in the [bootstrapping skele
 
 The CLI distribution requires `scala` and `scalac` (of the right major version) to be on the execution path. Unpack it wherever you like and add the `bin/` folder to your execution path.
 
+#### Scala.js 0.6.32
+* [0.6.32, Scala 2.13 (tgz, 22MB)]({{ site.production_url }}/files/scalajs_2.13-0.6.32.tgz)
+* [0.6.32, Scala 2.13 (zip, 22MB)]({{ site.production_url }}/files/scalajs_2.13-0.6.32.zip)
+* [0.6.32, Scala 2.12 (tgz, 29MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.32.tgz)
+* [0.6.32, Scala 2.12 (zip, 29MB)]({{ site.production_url }}/files/scalajs_2.12-0.6.32.zip)
+* [0.6.32, Scala 2.11 (tgz, 36MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.32.tgz)
+* [0.6.32, Scala 2.11 (zip, 36MB)]({{ site.production_url }}/files/scalajs_2.11-0.6.32.zip)
+* [0.6.32, Scala 2.10 (tgz, 30MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.32.tgz)
+* [0.6.32, Scala 2.10 (zip, 30MB)]({{ site.production_url }}/files/scalajs_2.10-0.6.32.zip)
+
 #### Scala.js 1.0.0-RC2
 * [1.0.0-RC2, Scala 2.13 (tgz, 21MB)]({{ site.production_url }}/files/scalajs_2.13-1.0.0-RC2.tgz)
 * [1.0.0-RC2, Scala 2.13 (zip, 21MB)]({{ site.production_url }}/files/scalajs_2.13-1.0.0-RC2.zip)

--- a/doc/internals/version-history.md
+++ b/doc/internals/version-history.md
@@ -5,6 +5,7 @@ title: Version history
 
 ## Version history of Scala.js
 
+- [0.6.32](/news/2020/01/24/announcing-scalajs-0.6.32/)
 - [1.0.0-RC2](/news/2019/12/13/announcing-scalajs-1.0.0-RC2/)
 - [1.0.0-RC1](/news/2019/11/26/announcing-scalajs-1.0.0-RC1/)
 - [0.6.31](/news/2019/11/21/announcing-scalajs-0.6.31/)


### PR DESCRIPTION
Optimistically targeted for announcing today.