### PR TITLE
Announcing Scala.js 1.0.0.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,8 +57,8 @@ colors:  #in hex code if not noted else
 
 ### VERSIONS ###
 versions:
-  scalaJS: 0.6.32
-  scalaJSBinary: 0.6
-  scalaJSDev: 1.0.0-RC2
-  scalaJSDevBinary: 1.0-RC2
-  scalaJSDOM: 0.9.8
+  scalaJS: 1.0.0
+  scalaJSBinary: 1
+  scalaJS06x: 0.6.32
+  scalaJS06xBinary: 0.6
+  scalaJSDOM: 1.0.0

--- a/_data/doc.yml
+++ b/_data/doc.yml
@@ -7,6 +7,8 @@
   subitems:
     - text: Basic tutorial
       url: /doc/tutorial/basic/
+    - text: Basic tutorial (0.6.x)
+      url: /doc/tutorial/basic/0.6.x.html
 - text: Scala.js for JavaScript developers
   url: /doc/sjs-for-js/
   subitems:

--- a/_posts/news/2020-02-25-announcing-scalajs-1.0.0.md
+++ b/_posts/news/2020-02-25-announcing-scalajs-1.0.0.md
@@ -1,0 +1,591 @@
+---
+layout: post
+title: Announcing Scala.js 1.0.0
+category: news
+tags: [releases]
+permalink: /news/2020/02/25/announcing-scalajs-1.0.0/
+---
+
+
+We are thrilled to announce the General Availability release of Scala.js 1.0.0!
+
+Scala.js is a close dialect of Scala compiling to JavaScript, featuring great portability wrt. Scala/JVM, interoperability with JavaScript, and performance.
+
+After 7 years of development, including 5 years of stability within the 0.6.x series, we are finally ready to present Scala.js 1.0.0.
+Quoting Antoine de Saint-Exupéry,
+
+> Perfection is achieved, not when there is nothing more to add, but when there is nothing left to take away.
+
+Scala.js 1.0.0 is the culmination of our efforts to simplify, specify, and future-proof all aspects of Scala.js, from the language semantics to the internal APIs, so that there is nothing left to take away.
+
+As the change in major version number witnesses, this release is *not* binary compatible with 0.6.x, nor with the previous milestones and RCs of the 1.x series.
+Libraries need to be recompiled and republished using Scala.js 1.0.0 to be compatible.
+Several libraries at the core of the Scala/Scala.js ecosystem have already been published and are available for Scala.js 1.0.0.
+
+Moreover, this release is not entirely source compatible with 0.6.x either (see [Breaking Changes](#breaking-changes) below).
+
+Here are some highlights of Scala.js 1.0.0:
+
+* Better interoperability with JavaScript libraries (see the [Enhancements](#enhancements) section below)
+* Improved portability with respect to Scala/JVM
+* Better run-time performance
+
+<!--more-->
+
+## Getting started
+
+If you are new to Scala.js, head over to [the tutorial]({{ BASE_PATH }}/tutorial/).
+
+If you need help with anything related to Scala.js, you may find our community [on Gitter](https://gitter.im/scala-js/scala-js) and [on Stack Overflow](https://stackoverflow.com/questions/tagged/scala.js).
+
+Bug reports can be filed [on GitHub](https://github.com/scala-js/scala-js/issues).
+
+## Preparations before upgrading from 0.6.x
+
+Before upgrading to 1.0.0, **we strongly recommend that you upgrade to Scala.js 0.6.32 or later**, and address all deprecation warnings.
+Since Scala.js 1.0.0 removes support for all the deprecated features in 0.6.x, it is easier to see the deprecation messages guiding you to the proper replacements.
+
+Moreover, you will need to upgrade your version of Scala to at least 2.11.12, 2.12.1 or 2.13.0 (the latest being 2.11.12, 2.12.10 and 2.13.1 as of this writing).
+Older versions (including all 2.10.x versions) are not supported anymore by Scala.js 1.x.
+
+### For sbt users
+
+Make sure that you explicitly use [`sbt-crossproject`](https://github.com/portable-scala/sbt-crossproject#migration-from-scalajs-06x-default-crossproject) instead of the default `crossProject` implementation.
+The old `crossProject` is deprecated in 0.6.32, but it is easy to overlook deprecations in the build itself.
+
+Additionally to the explicitly deprecated things, make sure to use `scalaJSLinkerConfig` instead of the following sbt settings:
+
+* `scalaJSSemantics`
+* `scalaJSModuleKind`
+* `scalaJSOutputMode`
+* `emitSourceMaps`
+* `relativeSourceMaps`
+* `scalaJSOptimizerOptions`
+
+Finally, if you are still using sbt 0.13.x, you will have to upgrade to sbt 1.2.1 or later (as of this writing, the latest release is 1.3.8).
+
+## Upgrade to 1.0.0 from 0.6.32 or later
+
+These instructions apply to sbt users.
+If you are using a different build tool, refer to that build tool's documentation for Scala.js support.
+
+As a first approximation, all you need to do is to update the version number in `project/plugins.sbt`:
+
+{% highlight scala %}
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0")
+{% endhighlight %}
+
+In addition, if you use some of the components that have been moved to separate repositories, you will need to add some more dependencies in `project/plugins.sbt`:
+
+If you use `scalajs-stubs`:
+
+* Change its version number to `"1.0.0"`
+
+If you use `jsDependencies` (or rely on the `jsDependencies` of your transitive dependencies):
+
+* Add `addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.0")` in `project/plugins.sbt`
+* Add `.enablePlugins(JSDependenciesPlugin)` to Scala.js `project`s
+* Add `.jsConfigure(_.enablePlugins(JSDependenciesPlugin))` to `crossProject`s
+
+If you use the Node.js with jsdom environment (`JSDOMNodeJSEnv`):
+
+* Add `libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0"` in `project/plugins.sbt`
+
+If you use the PhantomJS environment (`PhantomJSEnv`):
+
+* Add `addSbtPlugin("org.scala-js" % "sbt-scalajs-env-phantomjs" % "1.0.0")` in `project/plugins.sbt`
+
+If you use the Selenium environment (`SeleniumJSEnv`):
+
+* Change its version number to `"1.0.0"`
+
+**Note:** All the above version numbers coincide at `"1.0.0"` for this release, but they will independently evolve in the future.
+Therefore, do not "DRY up" your build by using a common constant (such as `scalaJSVersion`) for those dependencies, or your build will break when updating one of them in the future.
+
+Finally, if your build has
+
+{% highlight scala %}
+scalacOptions += "-P:scalajs:sjsDefinedByDefault"
+{% endhighlight %}
+
+you will need to remove it (Scala.js 1.x always behaves as if `sjsDefinedByDefault` were present).
+
+This should get your build up to speed to Scala.js 1.0.0.
+From there, you should be able to test whether things go smoothly, or whether you are affected by the breaking changes detailed below.
+
+## Breaking changes
+
+This section discusses the backward incompatible changes, which might affect your project.
+
+### Access to the global scope instead of the global object
+
+This is the only major breaking change at the language level.
+In Scala.js 1.x, `js.Dynamic.global` and `@JSGlobalScope` objects refer to the global *scope* of JavaScript, rather than the global *object*.
+Concretely, this has three consequences, which we outline below.
+Further information can be found in [the documentation about the global scope in Scala.js]({{ BASE_PATH }}/doc/interoperability/global-scope.html).
+
+#### Members can only be accessed with a statically known name which is a valid JavaScript identifier
+
+For example, the following is valid:
+
+{% highlight scala %}
+println(js.Dynamic.global.Math)
+{% endhighlight %}
+
+but the following variant, where the name `Math` is only known at run-time, is not valid anymore:
+
+{% highlight scala %}
+val mathName = "Math"
+println(js.Dynamic.global.selectDynamic(mathName))
+{% endhighlight %}
+
+The latter will cause a compile error.
+This is because it is not possible to perform dynamic lookups in the global scope.
+Similarly, accessing a member whose name is statically known but not a valid JavaScript identifier is also prohibited:
+
+{% highlight scala %}
+println(js.Dynamic.global.`not-a-valid-JS-identifier`)
+{% endhighlight %}
+
+#### Global scope objects cannot be stored in a separate `val`
+
+For example, the following is invalid and will cause a compile error:
+
+{% highlight scala %}
+val g = js.Dynamic.global
+{% endhighlight %}
+
+as well as:
+
+{% highlight scala %}
+def foo(x: Any): Unit = println(x)
+foo(js.Dynamic.global)
+{% endhighlight %}
+
+This follows from the previous rule.
+If the above two snippets were allowed, we could not check that we only access members with statically known names.
+
+The first snippet can be advantageously replaced by a renaming import:
+
+{% highlight scala %}
+import js.Dynamic.{global => g}
+{% endhighlight %}
+
+#### Accessing a member that is not declared causes a `ReferenceError` to be thrown
+
+This is a *run-time* behavior change, and in our experience the larger source of breakages in actual code.
+
+Previously, reading a non-existent member of the global object, such as
+
+{% highlight scala %}
+println(js.Dynamic.global.globalVarThatDoesNotExist)
+{% endhighlight %}
+
+would evaluate to `undefined`.
+In Scala.js 1.x, this throws a `ReferenceError`.
+Similarly, writing to a non-existent member, such as
+
+{% highlight scala %}
+js.Dynamic.global.globalVarThatDoesNotExist = 42
+{% endhighlight %}
+
+would previously *create* said global variable.
+In Scala.js 1.x, it also throws a `ReferenceError`.
+
+A typical use case of the previous behavior was to *test* whether a global variable was defined or not, e.g.,
+
+{% highlight scala %}
+if (js.isUndefined(js.Dynamic.global.Promise)) {
+  // Promises are not supported
+} else {
+  // Promises are supported
+}
+{% endhighlight %}
+
+This idiom is broken in Scala.js 1.x, and needs to be replaced by an explicit use of `js.typeOf`:
+
+{% highlight scala %}
+if (js.typeOf(js.Dynamic.global.Promise) == "undefined")
+{% endhighlight %}
+
+The `js.typeOf` "method" is magical when its argument is a member of a global scope object.
+
+### Scala.js emits ECMAScript 2015 code by default
+
+Now that ES 2015 has been supported by major JS engines for a while, it was time to emit ES 2015 code by default.
+The ES 2015 output has several advantages over the older ES 5.1 strict mode output:
+
+* `Throwable`s, by virtue of properly extending JavaScript's `Error`, have an `[[ErrorData]]` internal slot, and therefore receive proper debugging info in JS engines, allowing better display of stack traces and error messages in interactive debuggers.
+* Static fields and methods in JS classes are properly inherited. See [#2771](https://github.com/scala-js/scala-js/issues/2771).
+* The generated code is shorter.
+
+To revert to emitting ES 5.1 strict mode code, use the following sbt setting:
+
+{% highlight scala %}
+scalaJSLinkerConfig in ThisBuild ~= { _.withESFeatures(_.withUseECMAScript2015(false)) }
+{% endhighlight %}
+
+### With the default module kind `NoModule`, top-level exports are exported as top-level `var`s
+
+In Scala.js 0.6.x, top-level exports such as
+
+{% highlight scala %}
+@JSExportTopLevel("Foo")
+object Bar
+{% endhighlight %}
+
+were exported to JavaScript by being assigned to properties of the global object, for example as if by:
+
+{% highlight javascript %}
+window.Foo = <the object Bar>; // or global.Foo, etc.
+{% endhighlight %}
+
+In Scala.js 1.x, they are exported as top-level JavaScript `var`s instead, as if by:
+
+{% highlight javascript %}
+var Foo = <the object Bar>;
+{% endhighlight %}
+
+This ensures that code generated by Scala.js is completely generic with respect to which variables hold the global object, and hence works in any compliant JavaScript environment.
+
+However, it also means that the generated .js file must be interpreted as a proper *script* for the variables to be visible by other scripts.
+This may have compatibility consequences.
+
+### `js.UndefOr[A]` is now an alias for `A | Unit`
+
+Instead of defining `js.UndefOr[+A]` as its own type, it is now a simple type alias for `A | Unit`:
+
+{% highlight scala %}
+type UndefOr[+A] = A | Unit
+{% endhighlight %}
+
+The `Option`-like API is of course preserved.
+
+We do not expect this to cause any significant issue, but it may impact type inference in subtle ways that can cause compile errors for previously valid code.
+You may have to adjust some uses of `js.UndefOr` due to these changes.
+
+### `x eq y` now more closely matches the JVM behavior
+
+In Scala.js 0.6.x, `x eq y` always corresponds to JavaScript's `x === y`.
+This is almost always correct, but causes issues when comparing `+0.0` with `-0.0` or `NaN` with itself.
+
+In Scala.js 1.x, `x eq y` has been adapted to more closely match the JVM behavior, resulting in more portable code.
+It is equivalent to the old behavior except in the following cases:
+
+* `+0.0 eq -0.0` is now `false`
+* `NaN eq NaN` is now `true`
+
+The new behavior corresponds to JavaScript's [`Object.is(x, y)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) function.
+
+### `testHtml` replaces both `testHtmlFastOpt` and `testHtmlFullOpt`
+
+The separation of `testHtmlFastOpt` and `testHtmlFullOpt`, which were independent of the value of `scalaJSStage`, caused significant unfixable issues in 0.6.x.
+In Scala.js 1.x, both are replaced by a single task, `testHtml`.
+It is equivalent to the old `testHtmlFastOpt` if the value of `scalaJSStage` is `FastOptStage` (the default), and to `testHtmlFullOpt` if it is `FullOptStage`.
+This makes it more consistent with other tasks such as `run` and `test`.
+
+### Java system properties are not loaded from `__ScalaJSEnv` nor sbt's `javaOptions` anymore
+
+In 0.6.x, the sbt plugin automatically extracted `-D` options in `javaOptions`, and transferred them to the Java system properties API inside Scala.js, using a generated .js file filling in the magic variable `__ScalaJSEnv`.
+Scala.js 1.x does not support `__ScalaJSEnv` anymore, therefore `-D` options in `javaOptions` are now ignored.
+
+Use your own mechanism to transfer data from the build to your Scala.js code, for example source code generation.
+
+### A unique, simple sbt setting to control what JS files are `run` or `test`ed: `jsEnvInput`
+
+By default, only the .js file generated by `fastOptJS` or `fullOptJS` is given to the selected `jsEnv` to be `run` or `test`ed.
+In 0.6.x, there were several non-obvious task keys to modify this behavior: `resolvedJSDependencies`, `loadedJSEnv` and related.
+Moreover, the `JSEnv`s decided on their own, based on unclear heuristics, whether to treat the files as modules or not, and as what kind of module.
+
+Scala.js 1.x consolidates all of that into one simple task key `jsEnvInput` of type `Seq[org.scalajs.jsenv.Input]`, where an `Input` is an ADT with the following possible alternatives:
+
+* `Input.Script(script)`: a JavaScript file to load as a script
+* `Input.ESModule(module)`: a JavaScript file to load as an ECMAScript module (some JS envs may require a specific extension such as `.mjs` for this to work, due to limitations of the underlying engines)
+* `Input.CommonJSModule(module)`: a JavaScript file to load as a CommonJS module
+
+Not all `JSEnv`s support all kinds of `Input`s.
+
+The default value of `jsEnvInput` is a single `Input` whose type is derived from the `ModuleKind`, and which contains the output of `fastOptJS` or `fullOptJS`.
+
+### `scalajs-javalib-ex` was removed
+
+The artifact `scalajs-javalib-ex` is removed in 1.x.
+It only contained a partial implementation of `java.util.ZipInputStream`.
+If you were using it, we recommend that you integrate a copy of [its source code from Scala.js 0.6.x](https://github.com/scala-js/scala-js/tree/0.6.x/javalib-ex/src/main/scala/java/util/zip) into your project.
+
+### `js.use(x).as[T]` was removed
+
+The use cases for `js.use(x).as[T]` have been dramatically reduced by non-native JS classes (previously known as Scala.js-defined JS classes).
+This API seems virtually unused on the visible Web.
+Moreover, it was the only macro in the Scala.js standard library.
+
+We have therefore removed it from the standard library, and it is not provided anymore.
+On demand, we can republish it as a separate library, if you need it.
+
+### The Tools API has been split into 3 artifacts and its packages reorganized
+
+This only concerns consumers of the Tools API, i.e., tools that build on top of the Scala.js linker, such as ScalaFiddle.
+In Scala.js 0.6.x, all the tools were in one artifact `scalajs-tools`.
+This artifact has been split in two in Scala.js 1.x:
+
+* `scalajs-logging`: tiny logging API
+* `scalajs-linker-interface`: the extra stable interface for the linker API
+* `scalajs-linker`: the implementation of the linker API
+
+The `scalajs-linker` artifact can be loaded via reflection, while developing against the stable APIs in `scalajs-linker-interface`.
+
+In addition, the packages have been reorganized as follows:
+
+* `org.scalajs.core.ir`            -> `org.scalajs.ir`
+* `org.scalajs.core.tools.io`      -> gone (replaced by standard `java.nio.file.Path`-based APIs, and some abstractions in `org.scalajs.linker`)
+* `org.scalajs.core.tools.logging` -> `org.scalajs.logging`
+* `org.scalajs.core.tools.linker`  -> `org.scalajs.linker` and `org.scalajs.linker.interface`
+
+Additionally, the linker API has been refactored to be fully asynchronous in nature.
+
+### sbt 0.13.x is not supported anymore
+
+You will not be able to use Scala.js 1.0.0 with sbt 0.13.x.
+You will have to upgrade to sbt 1.2.1 or later.
+As of this writing, the latest version is 1.3.8.
+
+### Scala 2.10.x, 2.11.{0-11} and 2.12.0 are not supported anymore
+
+The title says it all: you cannot use Scala.js anymore with any of:
+
+{% highlight scala %}
+scalaVersion := "2.10.x" // for any x
+scalaVersion := "2.11.x" // for 0 <= x <= 11
+scalaVersion := "2.12.0"
+{% endhighlight %}
+
+* Scala 2.10.x is not supported at all,
+* Only 2.11.12 is still supported in the 2.11.x series, and
+* 2.12.1 and following are supported in the 2.12.x series, but not 2.12.0.
+
+## Enhancements
+
+There are very few enhancements in Scala.js 1.0.0.
+Scala.js 1.0.0 is focused on simplifying Scala.js, not on adding new features.
+Nevertheless, here are a few enhancements.
+
+### Scala.js can access `require` and other magical "global" variables of special JS environments
+
+The changes from global *object* to global *scope* mean that magical "global" variables provided by some JavaScript environments, such as `require` in Node.js, are now visible to Scala.js.
+For example, it is possible to dynamically call `require` as follows in Scala.js 1.x:
+
+{% highlight scala %}
+val pathToSomeAsset = "assets/logo.png"
+val someAsset = js.Dynamic.global.require(pathToSomeAsset)
+{% endhighlight %}
+
+We still recommend to use `@JSImport` and `CommonJSModule` for statically known imports.
+
+### Declaring inner classes in native JS classes
+
+Some JavaScript APIs define classes inside objects, as in the following example:
+
+{% highlight javascript %}
+class OuterClass {
+  constructor(x) {
+    this.InnerClass = class InnerClass {
+      someMethod() {
+        return x;
+      }
+    }
+  }
+}
+{% endhighlight %}
+
+allowing use sites to instantiate them as
+
+{% highlight javascript %}
+const outerObject = new OuterClass(42);
+const innerObject = new outerObject.InnerClass();
+console.log(innerObject.someMethod()); // prints 42
+{% endhighlight %}
+
+In Scala.js 0.6.x, it is very awkward to define a facade type for `OuterClass`, as illustrated [in issue #2398](https://github.com/scala-js/scala-js/issues/2398).
+Scala.js 1.x now allows to declare them very easily as inner JS classes:
+
+{% highlight scala %}
+@js.native
+@JSGlobal
+class OuterClass(x: Int) extends js.Object {
+  @js.native
+  class InnerClass extends js.Object {
+    def someMethod(): Int = js.native
+  }
+}
+{% endhighlight %}
+
+which in turns allows for the following call site:
+
+{% highlight scala %}
+val outerObject = new OuterClass(42)
+val innerObject = new outerObject.InnerClass()
+console.log(innerObject.someMethod()) // prints 42
+{% endhighlight %}
+
+### Nested non-native JS classes expose sane constructors to JavaScript
+
+It is now possible to declare non-native JS classes inside outer `class`es or inside `def`s, and use their `js.constructorOf` in a meaningful way.
+For example, one can define a method that creates a new JavaScript class every time it is invoked:
+
+{% highlight scala %}
+def makeGreeter(greetingFormat: String): js.Dynamic = {
+  class Greeter extends js.Object {
+    def greet(name: String): String =
+      println(greetingFormat.format(name))
+  }
+  js.constructorOf[Greeter]
+}
+{% endhighlight %}
+
+Assuming there is some native JavaScript function like
+
+{% highlight javascript %}
+function greetPeople(greeterClass) {
+  const greeter = new greeterClass();
+  greeter.greet("Jane");
+  greeter.greet("John");
+}
+{% endhighlight %}
+
+one could call it from Scala.js as:
+
+{% highlight scala %}
+val englishGreeterClass = makeGreeter("Hello, %s!")
+greetPeople(englishGreeterClass)
+val frenchGreeterClass = makeGreeter("Bonjour, %s!")
+greetPeople(frenchGreeterClass)
+val japaneseGreeterClass = makeGreeter("%sさん、こんにちは。")
+greetPeople(japaneseGreeterClass)
+{% endhighlight %}
+
+resulting in the following output:
+
+{% highlight text %}
+Hello, Jane!
+Hello, John!
+Bonjour, Jane!
+Bonjour, John!
+Janeさん、こんにちは。
+Johnさん、こんにちは。
+{% endhighlight %}
+
+In Scala.js 0.6.x, the above code would compile but produce incoherent results at run-time, because `js.constructorOf` was meaningless for nested classes.
+
+## Bugfixes
+
+Amongst others, the following bugs have been fixed since 0.6.32:
+
+* [#2800](https://github.com/scala-js/scala-js/issues/2800) Global `let`s, `const`s and `class`es cannot be accessed by Scala.js
+* [#2382](https://github.com/scala-js/scala-js/issues/2382) Name clash for `$outer` pointers of two different nesting levels (fixed for Scala 2.10 and 2.11; 2.12 did not suffer from the bug in 0.6.x)
+* [#3085](https://github.com/scala-js/scala-js/issues/3085) Linking error after the optimizer for `someInt.toDouble.compareTo(double)`
+
+See the full list of issues fixed in each of the milestones and release candidates of 1.0.0 on GitHub:
+
+* [1.0.0-M1](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.0-M1+is%3Aclosed)
+* [1.0.0-M2](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.0-M2+is%3Aclosed)
+* [1.0.0-M3](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.0-M3+is%3Aclosed)
+* [1.0.0-M4](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.0-M4+is%3Aclosed)
+* [1.0.0-M5](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.0-M5+is%3Aclosed)
+* [1.0.0-M6](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.0-M6+is%3Aclosed)
+* [1.0.0-M7](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.0-M7+is%3Aclosed)
+* [1.0.0-M8](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.0-M8+is%3Aclosed)
+* [1.0.0-RC1](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.0-RC1+is%3Aclosed)
+* [1.0.0-RC2](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.0-RC2+is%3Aclosed)
+* [1.0.0](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.0+is%3Aclosed)
+
+## Cross-building for Scala.js 0.6.x and 1.x
+
+If you want to cross-compile your libraries for Scala.js 0.6.x and 1.x, here are a couple tips.
+
+### Dynamically load a custom version of Scala.js
+
+Since the version of Scala.js is not decided by an sbt setting in `build.sbt`, but by the version of the sbt plugin in `project/plugins.sbt`, standard cross-building setups based on `++` cannot be applied.
+We recommend that you load the version of Scala.js from an environment variable.
+For example, you can do this in your `project/plugins.sbt` file:
+
+{% highlight scala %}
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+{% endhighlight %}
+
+You can then launch
+
+{% highlight bash %}
+$ sbt
+{% endhighlight %}
+
+from your command line to start up your build with Scala.js 1.0.0 by default, or
+
+{% highlight bash %}
+$ SCALAJS_VERSION=0.6.32 sbt
+{% endhighlight %}
+
+to use an older version of Scala.js.
+
+### Extra dependencies for JS environments
+
+You can further build on the above `val scalaJSVersion` to dynamically add dependencies on `scalajs-env-phantomjs` and/or `scalajs-env-jsdom-nodejs` if you use them:
+
+{% highlight scala %}
+// For Node.js with jsdom
+libraryDependencies ++= {
+  if (scalaJSVersion.startsWith("0.6.")) Nil
+  else Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0")
+}
+
+// For PhantomJS
+{
+  if (scalaJSVersion.startsWith("0.6.")) Nil
+  else Seq(addSbtPlugin("org.scala-js" % "sbt-scalajs-env-phantomjs" % "1.0.0"))
+}
+
+// For Selenium
+libraryDependencies += {
+  val v = if (scalaJSVersion.startsWith("0.6.")) "0.3.0" else "1.0.0"
+  libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % v
+}
+{% endhighlight %}
+
+In all cases, you can then use the source-compatible API in `build.sbt` to select your JS environment of choice.
+
+### Extra dependencies for `jsDependencies`
+
+Similarly, you can conditionally depend on `jsDependencies` as follows:
+
+{% highlight scala %}
+// For jsDependencies
+{
+  if (scalaJSVersion.startsWith("0.6.")) Nil
+  else Seq(addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.0"))
+}
+{% endhighlight %}
+
+In that case, you should unconditionally keep the
+
+{% highlight scala %}
+enablePlugins(JSDependenciesPlugin)
+{% endhighlight %}
+
+on the relevant projects.
+Scala.js 0.6.20 and later define a no-op `JSDependenciesPlugin` to allow for this scenario.
+
+### Conditional application of `-P:scalajs:sjsDefinedByDefault`
+
+In Scala.js 1.x, the flag `-P:scalajs:sjsDefinedByDefault` has been removed.
+However, if you have non-native JS types in your codebase, you need this flag in Scala.js 0.6.x.
+
+Add the following setting to your `build.sbt` to conditionally enable that flag:
+
+{% highlight scala %}
+scalacOptions ++= {
+  if (scalaJSVersion.startsWith("0.6.")) Seq("-P:scalajs:sjsDefinedByDefault")
+  else Nil
+}
+{% endhighlight %}

--- a/doc/all-api.md
+++ b/doc/all-api.md
@@ -5,6 +5,19 @@ title: All previous versions of the Scala.js API
 
 ## All previous versions of the API
 
+### Scala.js 1.0.0
+* [1.0.0 scalajs-library]({{ site.production_url }}/api/scalajs-library/1.0.0/scala/scalajs/js/index.html)
+* [1.0.0 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/1.0.0/)
+* [1.0.0 scalajs-ir]({{ site.production_url }}/api/scalajs-ir/1.0.0/org/scalajs/ir/index.html)
+* [1.0.0 scalajs-logging]({{ site.production_url }}/api/scalajs-logging/1.0.0/org/scalajs/logging/index.html)
+* [1.0.0 scalajs-linker-interface]({{ site.production_url }}/api/scalajs-linker-interface/1.0.0/org/scalajs/linker/interface/index.html) ([Scala.js version]({{ site.production_url }}/api/scalajs-linker-interface-js/1.0.0/org/scalajs/linker/interface/index.html))
+* [1.0.0 scalajs-linker]({{ site.production_url }}/api/scalajs-linker/1.0.0/org/scalajs/linker/index.html) ([Scala.js version]({{ site.production_url }}/api/scalajs-linker-js/1.0.0/org/scalajs/linker/index.html))
+* [1.0.0 scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/1.0.0/org/scalajs/jsenv/index.html)
+* [1.0.0 scalajs-env-nodejs]({{ site.production_url }}/api/scalajs-env-nodejs/1.0.0/org/scalajs/jsenv/nodejs/index.html)
+* [1.0.0 scalajs-js-envs-test-kit]({{ site.production_url }}/api/scalajs-js-envs-test-kit/1.0.0/org/scalajs/jsenv/test/index.html)
+* [1.0.0 scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/1.0.0/org/scalajs/testadapter/index.html)
+* [1.0.0 sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/1.0.0/#org.scalajs.sbtplugin.package)
+
 ### Scala.js 0.6.32
 * [0.6.32 scalajs-library]({{ site.production_url }}/api/scalajs-library/0.6.32/#scala.scalajs.js.package)
 * [0.6.32 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/0.6.32/)

--- a/doc/api.md
+++ b/doc/api.md
@@ -7,32 +7,18 @@ title: Scala.js API
 
 ### Latest version ({{ site.versions.scalaJS }})
 
-* [scalajs-library]({{ site.production_url }}/api/scalajs-library/latest/#scala.scalajs.js.package)
-* [sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/latest/#org.scalajs.sbtplugin.package)
+* [scalajs-library]({{ site.production_url }}/api/scalajs-library/latest/scala/scalajs/js/index.html)
 * [scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/latest/)
-* [scalajs-stubs]({{ site.production_url }}/api/scalajs-stubs/latest/)
-* [scalajs-ir]({{ site.production_url }}/api/scalajs-ir/latest/#org.scalajs.core.ir.package)
-* [scalajs-tools]({{ site.production_url }}/api/scalajs-tools/latest/#org.scalajs.core.tools.package) ([Scala.js version]({{ site.production_url }}/api/scalajs-tools-js/latest/#org.scalajs.core.tools.package))
-* [scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/latest/#org.scalajs.jsenv.package)
-* [scalajs-js-envs-test-kit]({{ site.production_url }}/api/scalajs-js-envs-test-kit/latest/#org.scalajs.jsenv.test.package)
-* [scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/latest/#org.scalajs.testadapter.package)
+* [scalajs-ir]({{ site.production_url }}/api/scalajs-ir/latest/org/scalajs/ir/index.html)
+* [scalajs-logging]({{ site.production_url }}/api/scalajs-logging/latest/org/scalajs/logging/index.html)
+* [scalajs-linker-interface]({{ site.production_url }}/api/scalajs-linker-interface/latest/org/scalajs/linker/interface/index.html) ([Scala.js version]({{ site.production_url }}/api/scalajs-linker-interface-js/latest/org/scalajs/linker/interface/index.html))
+* [scalajs-linker]({{ site.production_url }}/api/scalajs-linker/latest/org/scalajs/linker/index.html) ([Scala.js version]({{ site.production_url }}/api/scalajs-linker-js/latest/org/scalajs/linker/index.html))
+* [scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/latest/org/scalajs/jsenv/index.html)
+* [scalajs-env-nodejs]({{ site.production_url }}/api/scalajs-env-nodejs/latest/org/scalajs/jsenv/nodejs/index.html)
+* [scalajs-js-envs-test-kit]({{ site.production_url }}/api/scalajs-js-envs-test-kit/latest/org/scalajs/jsenv/test/index.html)
+* [scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/latest/org/scalajs/testadapter/index.html)
+* [sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/latest/#org.scalajs.sbtplugin.package)
 
 ### Previous versions
 
 [See APIs for previous versions of Scala.js](all-api.html)
-
-## JavaScript APIs
-
-### DOM API
-
-* [0.9.5 scalajs-dom]({{ site.production_url }}/api/scalajs-dom/0.9.5/#org.scalajs.dom.package)
-* [0.9.0 scalajs-dom]({{ site.production_url }}/api/scalajs-dom/0.9.0/#org.scalajs.dom.package)
-* [0.8.x scalajs-dom]({{ site.production_url }}/api/scalajs-dom/0.8/#org.scalajs.dom.package)
-* [0.7.x scalajs-dom]({{ site.production_url }}/api/scalajs-dom/0.7/#org.scalajs.dom.package)
-* [0.6 scalajs-dom]({{ site.production_url }}/api/scalajs-dom/0.6/#org.scalajs.dom.package)
-
-### jQuery API
-
-* [0.8.x scalajs-jquery]({{ site.production_url }}/api/scalajs-jquery/0.8/#org.scalajs.jquery.package)
-* [0.7.x scalajs-jquery]({{ site.production_url }}/api/scalajs-jquery/0.8/#org.scalajs.jquery.package)
-* [0.6 scalajs-jquery]({{ site.production_url }}/api/scalajs-jquery/0.6/#org.scalajs.jquery.package)

--- a/doc/internals/downloads.md
+++ b/doc/internals/downloads.md
@@ -7,6 +7,14 @@ We strongly recommend using the SBT plugin, as shown in the [bootstrapping skele
 
 The CLI distribution requires `scala` and `scalac` (of the right major version) to be on the execution path. Unpack it wherever you like and add the `bin/` folder to your execution path.
 
+#### Scala.js 1.0.0
+* [1.0.0, Scala 2.13 (tgz, 21MB)]({{ site.production_url }}/files/scalajs_2.13-1.0.0.tgz)
+* [1.0.0, Scala 2.13 (zip, 21MB)]({{ site.production_url }}/files/scalajs_2.13-1.0.0.zip)
+* [1.0.0, Scala 2.12 (tgz, 27MB)]({{ site.production_url }}/files/scalajs_2.12-1.0.0.tgz)
+* [1.0.0, Scala 2.12 (zip, 27MB)]({{ site.production_url }}/files/scalajs_2.12-1.0.0.zip)
+* [1.0.0, Scala 2.11 (tgz, 20MB)]({{ site.production_url }}/files/scalajs_2.11-1.0.0.tgz)
+* [1.0.0, Scala 2.11 (zip, 20MB)]({{ site.production_url }}/files/scalajs_2.11-1.0.0.zip)
+
 #### Scala.js 0.6.32
 * [0.6.32, Scala 2.13 (tgz, 22MB)]({{ site.production_url }}/files/scalajs_2.13-0.6.32.tgz)
 * [0.6.32, Scala 2.13 (zip, 22MB)]({{ site.production_url }}/files/scalajs_2.13-0.6.32.zip)

--- a/doc/internals/version-history.md
+++ b/doc/internals/version-history.md
@@ -5,6 +5,7 @@ title: Version history
 
 ## Version history of Scala.js
 
+- [1.0.0](/news/2020/02/25/announcing-scalajs-1.0.0/)
 - [0.6.32](/news/2020/01/24/announcing-scalajs-0.6.32/)
 - [1.0.0-RC2](/news/2019/12/13/announcing-scalajs-1.0.0-RC2/)
 - [1.0.0-RC1](/news/2019/11/26/announcing-scalajs-1.0.0-RC1/)

--- a/doc/project/dependencies.md
+++ b/doc/project/dependencies.md
@@ -21,11 +21,15 @@ Some Scala.js core libraries (such as the Scala.js library itself) do not need t
 
 Note that you can also use `%%%` in a Scala/JVM project, in which case it will be the same as `%%`. This allows you to use the same `libraryDependencies` settings when cross compiling Scala/JVM and Scala.js.
 
-## Depending on JavaScript libraries
+## Deprecated: Depending on JavaScript libraries
+
+The `jsDependencies` mechanism should be considered deprecated.
+Use [scalajs-bundler](https://scalacenter.github.io/scalajs-bundler/) instead.
 
 **Scala.js 1.x note:** since Scala.js 1.x, this functionality is not part of the core Scala.js sbt plugin.
 Instead, it is provided by [sbt-jsdependencies](https://github.com/scala-js/jsdependencies).
-You will need to add `addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.0-M1")` to `project/plugins.sbt`, as well as `enablePlugins(JSDependenciesPlugin)` to your Scala.js projects.
+
+The rest of this section applies to Scala.js 0.6.x only.
 
 Thanks to [WebJars](http://www.webjars.org/), you can easily fetch a JavaScript library like so:
 

--- a/doc/project/js-environments.md
+++ b/doc/project/js-environments.md
@@ -42,7 +42,7 @@ You will need to `npm install jsdom` for the above environment to work.
 **Scala.js 1.x:** The above setting requires the following line in your `project/plugins.sbt`:
 
 {% highlight scala %}
-libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0-M1"
+libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0"
 {% endhighlight %}
 
 **Scala.js 0.6.x:** This environment is selected by default if your application or one of its libraries declares a dependency on the DOM, with `jsDependencies += RuntimeDOM`.
@@ -60,10 +60,12 @@ jsEnv := PhantomJSEnv().value
 **Scala.js 1.x:** The above setting requires the following line in your `project/plugins.sbt`:
 
 {% highlight scala %}
-addSbtPlugin("org.scala-js" % "sbt-scalajs-env-phantomjs" % "1.0.0-M1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs-env-phantomjs" % "1.0.0")
 {% endhighlight %}
 
 ### <a name="phantomjs-no-auto-terminate"></a> Disabling auto-termination of PhantomJS
+
+**Scala.js 0.6.x only**
 
 By default, the PhantomJS interpreter terminates itself as soon as the `main()` method returns.
 This may not be what you want, if for example you register time-outs or use WebSockets.
@@ -88,7 +90,7 @@ jsEnv := PhantomJSEnv(args = Seq("arg1", "arg2")).value
 {% endhighlight %}
 
 For more options of the PhantomJS environment, see
-[the Scaladoc of `PhantomJSEnv`]({{ site.production_url }}/api/sbt-scalajs/{{ site.versions.scalaJS }}/#org.scalajs.sbtplugin.ScalaJSPlugin$$AutoImport$).
+[the Scaladoc of `PhantomJSEnv`]({{ site.production_url }}/api/sbt-scalajs-env-phantomjs/1.0.0/org/scalajs/jsenv/phantomjs/sbtplugin/PhantomJSEnvPlugin$$autoImport$.html).
 
 ## Selenium
 

--- a/doc/tutorial/basic/0.6.x.md
+++ b/doc/tutorial/basic/0.6.x.md
@@ -1,11 +1,11 @@
 ---
 layout: doc
-title: Basic tutorial
+title: Basic tutorial (Scala.js 0.6.x)
 ---
 
-**This page applies only to Scala.js 1.x. If you need 0.6.x, [go the older tutorial for Scala.js 0.6.x](./0.6.x.html).**
+**This page applies only to Scala.js 0.6.x. [Go the newer tutorial for Scala.js 1.x](./).**
 
-This is a step-by-step tutorial where we start with the setup of a Scala.js sbt project and end up having some user interaction and unit testing. The code created in this tutorial is available with one commit per step in the [scalajs-tutorial](https://github.com/scala-js/scalajs-tutorial) repository on GitHub.
+This is a step-by-step tutorial where we start with the setup of a Scala.js sbt project and end up having some user interaction and unit testing. The code created in this tutorial is available with one commit per step in the [scalajs-tutorial](https://github.com/scala-js/scalajs-tutorial/tree/0.6.x) repository on GitHub.
 
 ## <a name="prerequisites"></a> Step 0: Prerequisites
 
@@ -27,7 +27,7 @@ To setup Scala.js in a new sbt project, we need to do two things:
 Adding the Scala.js sbt plugin is a one-liner in `project/plugins.sbt` (all file names we write in this tutorial are relative to the project root):
 
 {% highlight scala %}
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "{{ site.versions.scalaJS }}")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "{{ site.versions.scalaJS06x }}")
 {% endhighlight %}
 
 We also setup basic project settings and enable this plugin in the sbt build file (`build.sbt`, in the project root directory):
@@ -36,7 +36,7 @@ We also setup basic project settings and enable this plugin in the sbt build fil
 enablePlugins(ScalaJSPlugin)
 
 name := "Scala.js Tutorial"
-scalaVersion := "2.13.1" // or any other Scala version >= 2.11.12
+scalaVersion := "2.13.1" // or any other Scala version >= 2.10.2
 
 // This is an application with a main method
 scalaJSUseMainModuleInitializer := true
@@ -73,7 +73,7 @@ As you expect, this will simply print "HelloWorld" when run. To run this, simply
     sbt:Scala.js Tutorial> run
     [info] Compiling 1 Scala source to (...)/scalajs-tutorial/target/scala-2.13/classes ...
     [info] Fast optimizing (...)/scalajs-tutorial/target/scala-2.13/scala-js-tutorial-fastopt.js
-    [info] Running tutorial.webapp.TutorialApp. Hit any key to interrupt.
+    [info] Running tutorial.webapp.TutorialApp
     Hello world!
     [success] (...)
 
@@ -173,7 +173,8 @@ We now create a method that allows us to append a `<p>` tag with a given text to
 {% highlight scala %}
 def appendPar(targetNode: dom.Node, text: String): Unit = {
   val parNode = document.createElement("p")
-  parNode.textContent = text
+  val textNode = document.createTextNode(text)
+  parNode.appendChild(textNode)
   targetNode.appendChild(parNode)
 }
 {% endhighlight %}
@@ -243,50 +244,108 @@ Since we now have a method that is callable from JavaScript, all we have to do i
 Reload your HTML page (remember, sbt compiles your code automatically) and try to click the button. It should add a new
 paragraph saying "You clicked the button!" each time you click it.
 
-## <a name="setup-ui-in-scala-js"></a> Step 5: Setup the UI in Scala.js
+## <a name="using-jquery"></a> Step 5: Using jQuery
 
-Previously, we have prepared the UI as an HTML document, then manipulated it from Scala.js code.
-That approach required us to manually *export* the method used for the `onclick` event of the button, which is cumbersome.
-We can avoid this issue by building the UI directly from the Scala.js code.
+Larger web applications have a tendency to set up reactions to events in JavaScript rather than specifying attributes.
+We will transform our current mini-application to use this paradigm with the help of jQuery. Also we will replace all
+usages of the DOM API with jQuery.
 
-Instead of preparing the button in the HTML, we can add the following code to the `main` method in Scala.js:
+### Depending on jQuery
+
+Just like for the DOM, there is a typed library for jQuery available in Scala.js: [scalajs-jquery](https://github.com/sjrd/scala-js-jquery) (there is [a livelier fork](https://github.com/exoego/scala-js-jquery) which you may prefer if it already supports the version of Scala you are using).
+Add the following line in your `build.sbt` by:
 
 {% highlight scala %}
-val button = document.createElement("button")
-button.textContent = "Click me!"
-button.addEventListener("click", { (e: dom.MouseEvent) =>
-  addClickedMessage()
-})
-document.body.appendChild(button)
+libraryDependencies += "be.doeraene" %%% "scalajs-jquery" % "1.0.0"
 {% endhighlight %}
 
-This uses an anonymous function that we give to `addEventListener`.
-It is very similar to the way we write an arrow function in JavaScript, except that the parameter is explicitly typed.
+Don't forget to reload the sbt configuration now:
 
-We can remove the `<button>` tag from the HTML file, and hence remove the `@JSExportTopLevel` annotation on `addClickedMessage()` (even though it will be indirectly called through the anonymous function).
+1. Hit enter to abort the `~fastOptJS` command
+2. Type `reload`
+3. Start `~fastOptJS` again
 
-As a last touch, we extract the setup of the UI in a separate method `def setupUI()`, which we will call only once the DOM is loaded, instead of synchronously from the `main` method:
+Again, make sure to update your IDE project files if you are using a plugin.
+
+### Using jQuery
+
+In `TutorialApp.scala`, remove the imports for the DOM, and add the import for jQuery:
+
+{% highlight scala %}
+import org.scalajs.jquery._
+{% endhighlight %}
+
+This allows you to easily access the `jQuery` main object of jQuery in your code (also known as `$`).
+
+We can now remove `appendPar` and replace all calls to it by the simple:
+
+{% highlight scala %}
+jQuery("body").append("<p>[message]</p>")
+{% endhighlight %}
+
+Where `[message]` is the string originally passed to `appendPar`, for example:
+
+{% highlight scala %}
+jQuery("body").append("<p>Hello World</p>")
+{% endhighlight %}
+
+If you try to reload your webpage now, it will not work (typically a `TypeError` would be reported in the console). The
+problem is that we haven't included the jQuery library itself, which is a plain JavaScript library.
+
+### Adding JavaScript libraries
+
+An option is to include `jquery.js` from an external source, such as [jsDelivr](http://www.jsdelivr.com/).
+
+{% highlight html %}
+<script type="text/javascript" src="http://cdn.jsdelivr.net/jquery/2.2.1/jquery.js"></script>
+{% endhighlight %}
+
+This can easily become very cumbersome, if you depend on multiple libraries. The Scala.js sbt plugin provides a
+mechanism for libraries to declare the plain JavaScript libraries they depend on and bundle them in a single file. All
+you have to do is activate this and then include the file.
+
+In your `build.sbt`, set:
+
+{% highlight scala %}
+skip in packageJSDependencies := false
+jsDependencies +=
+  "org.webjars" % "jquery" % "2.2.1" / "jquery.js" minified "jquery.min.js"
+{% endhighlight %}
+
+After reloading and rerunning `fastOptJS`, this will create `scala-js-tutorial-jsdeps.js` containing all JavaScript
+libraries next to the main JavaScript file. We can then simply include this file and don't need to worry about
+JavaScript libraries anymore:
+
+{% highlight html %}
+<!-- Include JavaScript dependencies -->
+<script type="text/javascript" src="./target/scala-2.13/scala-js-tutorial-jsdeps.js"></script>
+{% endhighlight %}
+
+### Setup UI in Scala.js
+
+We still want to get rid of the `onclick` attribute of our `<button>`. After removing the attribute, we add the
+`setupUI` method, in which we use jQuery to add an event handler to the button. We also move the "Hello World" message
+into this function.
+
+{% highlight scala %}
+def setupUI(): Unit = {
+  jQuery("body").append("<p>Hello World</p>")
+  jQuery("#click-me-button").click(() => addClickedMessage())
+}
+{% endhighlight %}
+
+Since we do not call `addClickedMessage` from plain JavaScript anymore, we can remove the `@JSExportTopLevel` annotation (and the corresponding import).
+
+Finally, we add a last call to `jQuery` in the main method, in order to execute `setupUI`, once the DOM is loaded:
 
 {% highlight scala %}
 def main(args: Array[String]): Unit = {
-  document.addEventListener("DOMContentLoaded", { (e: dom.Event) =>
-    setupUI()
-  })
-}
-
-def setupUI(): Unit = {
-  val button = document.createElement("button")
-  button.textContent = "Click me!"
-  button.addEventListener("click", { (e: dom.MouseEvent) =>
-    addClickedMessage()
-  })
-  document.body.appendChild(button)
-
-  appendPar(document.body, "Hello World")
+  jQuery(() => setupUI())
 }
 {% endhighlight %}
 
-You can now refresh the webpage to test the above changes.
+Again, since we are not calling `setupUI` directly from plain JavaScript, we do not need to export it (even though
+jQuery will call it through that callback).
 
 We now have an application whose UI is completely setup from within Scala.js. The next step will show how we can test
 this application.
@@ -303,32 +362,17 @@ details.
 Before we start writing tests which we will be able to run through the sbt console, we first have to solve another
 issue. Remember the task `run`? If you try to invoke it now, you will see something like this:
 
-    sbt:Scala.js Tutorial> run
-    [info] Running tutorial.webapp.TutorialApp. Hit any key to interrupt.
-    (...)/scalajs-tutorial/target/scala-2.13/scala-js-tutorial-fastopt.js:819
-        $thiz.Lorg_scalajs_dom_package$__f_window = window;
-                                                    ^
+    > run
+    [info] Running tutorial.webapp.TutorialApp
+    [error] TypeError: (0 , $m_Lorg_scalajs_jquery_package$(...).jQuery$1) is not a function
+    [error]     at $c_Ltutorial_webapp_TutorialApp$.main__AT__V (.../TutorialApp.scala:9:11)
+    [error]     ...
+    [trace] Stack trace suppressed: run last compile:run for the full output.
+    [error] (compile:run) org.scalajs.jsenv.ExternalJSEnv$NonZeroExitException: Node.js exited with code 1
+    [error] Total time: 1 s, completed Oct 13, 2016 3:06:00 PM
 
-    ReferenceError: window is not defined
-        at $p_Lorg_scalajs_dom_package$__window$lzycompute__Lorg_scalajs_dom_raw_Window ((...)/org/scalajs/dom/package.scala:219:40)
-        ...
-        at $c_Ltutorial_webapp_TutorialApp$.main__AT__V ((...)/tutorial/webapp/TutorialApp.scala:8:5)
-        ...
-    [error] org.scalajs.jsenv.ExternalJSRun$NonZeroExitException: exited with code 1
-    [error]         at org.scalajs.jsenv.ExternalJSRun$$anon$1.run(ExternalJSRun.scala:186)
-    [error] stack trace is suppressed; run last Compile / run for the full output
-    [error] (Compile / run) org.scalajs.jsenv.ExternalJSRun$NonZeroExitException: exited with code 1
-    [error] Total time: (...)
-
-The issue we encounter is that our `main` method tries to access DOM functionality, which is not available in Node.js.
-
-To make the DOM available, add the following to your `project/plugins.sbt`:
-
-{% highlight scala %}
-libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0"
-{% endhighlight %}
-
-and the following to your `build.sbt`:
+What basically happens here is that jQuery (which is automatically included because of `jsDependencies`) cannot properly load, because there is no DOM available in Node.js.
+To make the DOM available, add the following to your `build.sbt`:
 
 {% highlight scala %}
 jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
@@ -345,7 +389,7 @@ After reloading, you can invoke `run` successfully:
     [info] Running tutorial.webapp.TutorialApp
     [success] (...)
 
-Alternatively to Node.js with jsdom, you can use [Selenium](http://docs.seleniumhq.org/).
+Alternatively to Node.js with jsdom, you can use [PhantomJS](http://phantomjs.org/) or even [Selenium](http://docs.seleniumhq.org/).
 You can find more information about this in the [documentation about JavaScript environments]({{ BASE_PATH }}/doc/project/js-environments.html).
 
 ### Adding uTest
@@ -366,11 +410,7 @@ package tutorial.webapp
 
 import utest._
 
-import scala.scalajs.js
-
-import org.scalajs.dom
-import org.scalajs.dom.document
-import org.scalajs.dom.ext._
+import org.scalajs.jquery._
 
 object TutorialTest extends TestSuite {
 
@@ -379,18 +419,14 @@ object TutorialTest extends TestSuite {
 
   def tests = Tests {
     test("HelloWorld") {
-      assert(document.querySelectorAll("p").count(_.textContent == "Hello World") == 1)
+      assert(jQuery("p:contains('Hello World')").length == 1)
     }
   }
 }
 {% endhighlight %}
 
-This test uses `querySelectorAll` to find all the `<p>` elements in the document, and `count` those whose `textContent` is the `"Hello World"`.
-The `count` method is part of the Scala collections API, and is provided on DOM `NodeList`s by the
-
-{% highlight scala %}
-import org.scalajs.dom.ext._
-{% endhighlight %}
+This test uses jQuery to verify that our page contains exactly one `<p>` element which contains the text "Hello World"
+after the UI has been set up.
 
 To run this test, simply invoke the `test` task:
 
@@ -407,15 +443,28 @@ Just like `run`, the `test` task uses Node.js to execute your tests.
 
 ### A more complex test
 
-We also would like to test the functionality of our button:
+We also would like to test the functionality of our button. For this we face another small issue: the button doesn't
+exist when testing, since the tests start with an empty DOM tree. To solve this, we create the button in the `setupUI`
+method and remove it from the HTML:
+
+{% highlight scala %}
+jQuery("""<button type="button">Click me!</button>""")
+  .click(() => addClickedMessage())
+  .appendTo(jQuery("body"))
+{% endhighlight %}
+
+This brings another unexpected advantage: We don't need to give it an ID anymore but can directly use the jQuery object
+to install the on-click handler.
+
+We now define the `ButtonClick` test just below the `HelloWorld` test:
 
 {% highlight scala %}
 test("ButtonClick") {
   def messageCount =
-    document.querySelectorAll("p").count(_.textContent == "You clicked the button!")
+    jQuery("p:contains('You clicked the button!')").length
 
-  val button = document.querySelector("button").asInstanceOf[dom.html.Button]
-  assert(button != null && button.textContent == "Click me!")
+  val button = jQuery("button:contains('Click me!')")
+  assert(button.length == 1)
   assert(messageCount == 0)
 
   for (c <- 1 to 5) {
@@ -475,6 +524,8 @@ We also need to create our final production HTML file `scalajs-tutorial.html` wh
     <title>The Scala.js Tutorial</title>
   </head>
   <body>
+    <!-- Include JavaScript dependencies -->
+    <script type="text/javascript" src="./target/scala-2.13/scala-js-tutorial-jsdeps.js"></script>
     <!-- Include Scala.js compiled code -->
     <script type="text/javascript" src="./target/scala-2.13/scala-js-tutorial-opt.js"></script>
   </body>


### PR DESCRIPTION
And update the website to use 1.x by default everywhere.

The tutorial is duplicated, with one version for 1.x (the default), and a legacy version for 0.6.x.

---

Not to be merged yet, but review welcome :)