### PR TITLE
Fix API links for Scala.js 1.0.0

### DIFF
--- a/doc/interoperability/facade-types.md
+++ b/doc/interoperability/facade-types.md
@@ -73,7 +73,7 @@ is omitted entirely (or set to `undefined`). The value is only indicative, as
 implicit documentation.
 
 Fields, parameters, or result types that can have different, unrelated types, can be accurately typed with the
-[pseudo-union type `A | B`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/#scala.scalajs.js.$bar).
+[pseudo-union type `A | B`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/scala/scalajs/js/$bar.html).
 
 Methods can be overloaded. This is useful to type accurately some APIs that
 behave differently depending on the number or types of arguments.
@@ -607,5 +607,5 @@ When using `js.Dynamic`, you are very close to writing raw JavaScript within
 Scala.js, with all the warts of the language coming to haunt you.
 However, to get the full extent of JavaScriptish code, you can import the
 implicit conversions in
-[js.DynamicImplicts]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/#scala.scalajs.js.DynamicImplicits$).
+[js.DynamicImplicts]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/scala/scalajs/js/DynamicImplicits$.html).
 Use at your own risk!

--- a/doc/interoperability/sjs-defined-js-classes.md
+++ b/doc/interoperability/sjs-defined-js-classes.md
@@ -445,7 +445,7 @@ With run-time overload resolution, however, the type tests are executed again, a
 
 ### `js.constructorOf[C]`
 
-To obtain the JavaScript constructor function of a JS class (native or not) without instantiating it nor exporting it, you can use [`js.constructorOf[C]`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/#scala.scalajs.js.package@constructorOf[T<:scala.scalajs.js.Any]:scala.scalajs.js.Dynamic), whose signature is:
+To obtain the JavaScript constructor function of a JS class (native or not) without instantiating it nor exporting it, you can use [`js.constructorOf[C]`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/scala/scalajs/js/index.html#constructorOf[T<:scala.scalajs.js.Any]:scala.scalajs.js.Dynamic), whose signature is:
 
 {% highlight scala %}
 package object js {
@@ -460,7 +460,7 @@ This can be useful to give to JavaScript libraries expecting constructor functio
 
 ### `js.ConstructorTag[C]`
 
-[`js.ConstructorTag[C]`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/scala/scalajs/js/ConstructorTag.html) is to [`js.constructorOf[C]`]({{ site.production_url }}/api/scalajs-library/latest/#scala.scalajs.js.package@constructorOf[T<:scala.scalajs.js.Any]:scala.scalajs.js.Dynamic) as `ClassTag[C]` is to `classOf[C]`, i.e., you can use an `implicit` parameter of type `js.ConstructorTag[C]` to implicitly get a `js.constructorOf[C]`.
+[`js.ConstructorTag[C]`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/scala/scalajs/js/ConstructorTag.html) is to [`js.constructorOf[C]`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/scala/scalajs/js/index.html#constructorOf[T<:scala.scalajs.js.Any]:scala.scalajs.js.Dynamic) as `ClassTag[C]` is to `classOf[C]`, i.e., you can use an `implicit` parameter of type `js.ConstructorTag[C]` to implicitly get a `js.constructorOf[C]`.
 For example:
 
 {% highlight scala %}

--- a/doc/interoperability/sjs-defined-js-classes.md
+++ b/doc/interoperability/sjs-defined-js-classes.md
@@ -445,7 +445,7 @@ With run-time overload resolution, however, the type tests are executed again, a
 
 ### `js.constructorOf[C]`
 
-To obtain the JavaScript constructor function of a JS class (native or not) without instantiating it nor exporting it, you can use [`js.constructorOf[C]`]({{ site.production_url }}/api/scalajs-library/latest/#scala.scalajs.js.package@constructorOf[T<:scala.scalajs.js.Any]:scala.scalajs.js.Dynamic), whose signature is:
+To obtain the JavaScript constructor function of a JS class (native or not) without instantiating it nor exporting it, you can use [`js.constructorOf[C]`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/#scala.scalajs.js.package@constructorOf[T<:scala.scalajs.js.Any]:scala.scalajs.js.Dynamic), whose signature is:
 
 {% highlight scala %}
 package object js {
@@ -460,7 +460,7 @@ This can be useful to give to JavaScript libraries expecting constructor functio
 
 ### `js.ConstructorTag[C]`
 
-[`js.ConstructorTag[C]`]({{ site.production_url }}/api/scalajs-library/latest/#scala.scalajs.js.ConstructorTag) is to [`js.constructorOf[C]`]({{ site.production_url }}/api/scalajs-library/latest/#scala.scalajs.js.package@constructorOf[T<:scala.scalajs.js.Any]:scala.scalajs.js.Dynamic) as `ClassTag[C]` is to `classOf[C]`, i.e., you can use an `implicit` parameter of type `js.ConstructorTag[C]` to implicitly get a `js.constructorOf[C]`.
+[`js.ConstructorTag[C]`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/scala/scalajs/js/ConstructorTag.html) is to [`js.constructorOf[C]`]({{ site.production_url }}/api/scalajs-library/latest/#scala.scalajs.js.package@constructorOf[T<:scala.scalajs.js.Any]:scala.scalajs.js.Dynamic) as `ClassTag[C]` is to `classOf[C]`, i.e., you can use an `implicit` parameter of type `js.ConstructorTag[C]` to implicitly get a `js.constructorOf[C]`.
 For example:
 
 {% highlight scala %}

--- a/doc/interoperability/types.md
+++ b/doc/interoperability/types.md
@@ -140,7 +140,7 @@ Primitive JavaScript types (`number`, `boolean`, `string`, `null` and
 [above](#type-correspondence).
 
 For other pre-defined JavaScript types, such as arrays and functions, the package `scala.scalajs.js`
-([ScalaDoc]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/#scala.scalajs.js.package))
+([ScalaDoc]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/scala/scalajs/js/index.html))
 provides dedicated definitions.
 
 The class hierarchy for these standard types is as follows:
@@ -283,7 +283,7 @@ want to. The basic entry point is `js.Dynamic.global`, which is a dynamically
 typed view of the JavaScript global scope. You can select any global variable
 of JavaScript as a a member of `js.Dynamic.global`, e.g.,
 `js.Dynamic.global.Math`, which will be typed as a
-[`js.Dynamic`]({{ site.production_url }}/api/scalajs-library/latest/#scala.scalajs.js.Dynamic).
+[`js.Dynamic`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}//scala/scalajs/js/Dynamic.html).
 
 You can read and write any field of a `js.Dynamic`, as well as call any method
 with any number of arguments, and you always receive back a `js.Dynamic`.

--- a/doc/interoperability/types.md
+++ b/doc/interoperability/types.md
@@ -283,7 +283,7 @@ want to. The basic entry point is `js.Dynamic.global`, which is a dynamically
 typed view of the JavaScript global scope. You can select any global variable
 of JavaScript as a a member of `js.Dynamic.global`, e.g.,
 `js.Dynamic.global.Math`, which will be typed as a
-[`js.Dynamic`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}//scala/scalajs/js/Dynamic.html).
+[`js.Dynamic`]({{ site.production_url }}/api/scalajs-library/{{ site.versions.scalaJS }}/scala/scalajs/js/Dynamic.html).
 
 You can read and write any field of a `js.Dynamic`, as well as call any method
 with any number of arguments, and you always receive back a `js.Dynamic`.

--- a/doc/project/building.md
+++ b/doc/project/building.md
@@ -80,7 +80,7 @@ scalaJSLinkerConfig ~= { _.withOptimizer(false) }
 {% endhighlight %}
 
 `scalaJSLinkerConfig` contains various other options controlling the Scala.js linker.
-See [the Scaladoc of `StandardLinker.Config`]({{ site.production_url }}/api/scalajs-tools/{{ site.versions.scalaJS }}/#org.scalajs.core.tools.linker.StandardLinker$$Config) for details.
+See [the Scaladoc of `StandardLinker.Config`]({{ site.production_url }}/api/scalajs-linker-interface/{{ site.versions.scalaJS }}/org/scalajs/linker/interface/StandardConfig.html) for details.
 
 ## Full-Optimize
 

--- a/doc/project/js-environments.md
+++ b/doc/project/js-environments.md
@@ -90,7 +90,7 @@ jsEnv := PhantomJSEnv(args = Seq("arg1", "arg2")).value
 {% endhighlight %}
 
 For more options of the PhantomJS environment, see
-[the Scaladoc of `PhantomJSEnv`]({{ site.production_url }}/api/sbt-scalajs-env-phantomjs/{{ site.versions.scalaJS }}/org/scalajs/jsenv/phantomjs/sbtplugin/PhantomJSEnvPlugin$$autoImport$.html).
+[the Scaladoc of `PhantomJSEnv`]({{ site.production_url }}/api/sbt-scalajs-env-phantomjs/1.0.0/org/scalajs/jsenv/phantomjs/sbtplugin/PhantomJSEnvPlugin$$autoImport$.html).
 
 ## Selenium
 

--- a/doc/project/js-environments.md
+++ b/doc/project/js-environments.md
@@ -26,7 +26,7 @@ Then run `nvm` to install the version of Node.js that you want:
     nvm install 5.0
 
 For more options of the Node.js environment, see
-[the Scaladoc of `NodeJSEnv`]({{ site.production_url }}/api/scalajs-js-envs/{{ site.versions.scalaJS }}/#org.scalajs.jsenv.nodejs.NodeJSEnv).
+[the Scaladoc of `NodeJSEnv`]({{ site.production_url }}/api/scalajs-env-nodejs/{{ site.versions.scalaJS }}/org/scalajs/jsenv/nodejs/NodeJSEnv.html).
 
 ## Node.js with JSDOM
 
@@ -90,7 +90,7 @@ jsEnv := PhantomJSEnv(args = Seq("arg1", "arg2")).value
 {% endhighlight %}
 
 For more options of the PhantomJS environment, see
-[the Scaladoc of `PhantomJSEnv`]({{ site.production_url }}/api/sbt-scalajs-env-phantomjs/1.0.0/org/scalajs/jsenv/phantomjs/sbtplugin/PhantomJSEnvPlugin$$autoImport$.html).
+[the Scaladoc of `PhantomJSEnv`]({{ site.production_url }}/api/sbt-scalajs-env-phantomjs/{{ site.versions.scalaJS }}/org/scalajs/jsenv/phantomjs/sbtplugin/PhantomJSEnvPlugin$$autoImport$.html).
 
 ## Selenium
 


### PR DESCRIPTION
I noticed that a few API links were broken, so here's a PR to fix them.

Some parts of the documentation might need to be rewritten for 1.0.0. I only fixed the links I could fix; if I didn't find something in the 1.0.0 API docs, I didn't fix the link.