### PR TITLE
Announcing Scala.js 1.0.1.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ colors:  #in hex code if not noted else
 
 ### VERSIONS ###
 versions:
-  scalaJS: 1.0.0
+  scalaJS: 1.0.1
   scalaJSBinary: 1
   scalaJS06x: 0.6.32
   scalaJS06xBinary: 0.6

--- a/_posts/news/2020-03-10-announcing-scalajs-1.0.1.md
+++ b/_posts/news/2020-03-10-announcing-scalajs-1.0.1.md
@@ -1,0 +1,48 @@
+---
+layout: post
+title: Announcing Scala.js 1.0.1
+category: news
+tags: [releases]
+permalink: /news/2020/03/10/announcing-scalajs-1.0.1/
+---
+
+
+We are pleased to announce the release of Scala.js 1.0.1!
+
+This is mostly a bugfix release, including a fix for a regression affecting extensions of the JDK ([#3950](https://github.com/scala-js/scala-js/issues/3950)).
+
+Read on for more details.
+
+<!--more-->
+
+## Getting started
+
+If you are new to Scala.js, head over to [the tutorial]({{ BASE_PATH }}/tutorial/).
+
+If you need help with anything related to Scala.js, you may find our community [on Gitter](https://gitter.im/scala-js/scala-js) and [on Stack Overflow](https://stackoverflow.com/questions/tagged/scala.js).
+
+Bug reports can be filed [on GitHub](https://github.com/scala-js/scala-js/issues).
+
+## Release notes
+
+If upgrading from Scala.js 0.6.x, make sure to read [the release notes of Scala.js 1.0.0`]({{ BASE_PATH }}/news/2020/02/25/announcing-scalajs-1.0.0/) first, as it contains a host of important information, including breaking changes.
+
+As a patch release, 1.0.1 is backward and forward binary compatible with 1.0.0.
+Libraries compiled with 1.0.0 can be used with 1.0.1 without change, and conversely.
+As a reminder, libraries compiled with 0.6.x cannot be used with Scala.js 1.x; they must be republished with 1.x first.
+
+## Miscellaneous
+
+### Upgrade to GCC v20200101
+
+The Google Closure Compiler used internally by Scala.js for `fullOptJS` has been upgraded to v20200101.
+
+## Bug fixes
+
+Among others, the following bugs have been fixed in 0.6.32:
+
+* [#3950](https://github.com/scala-js/scala-js/issues/3950) Static forwarders are not generated for static nested objects
+* [#3984](https://github.com/scala-js/scala-js/issues/3984) `(-0.0).getClass()` returns `classOf[Integer]` instead of `classOf[Float]`
+* [#3983](https://github.com/scala-js/scala-js/issues/3983) With strict floats, `someDouble.getClass()` erroneously returns `Float`
+
+You can find the full list [on GitHub](https://github.com/scala-js/scala-js/issues?q=is%3Aissue+milestone%3Av1.0.1+is%3Aclosed).

--- a/doc/all-api.md
+++ b/doc/all-api.md
@@ -5,6 +5,19 @@ title: All previous versions of the Scala.js API
 
 ## All previous versions of the API
 
+### Scala.js 1.0.1
+* [1.0.1 scalajs-library]({{ site.production_url }}/api/scalajs-library/1.0.1/scala/scalajs/js/index.html)
+* [1.0.1 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/1.0.1/)
+* [1.0.1 scalajs-ir]({{ site.production_url }}/api/scalajs-ir/1.0.1/org/scalajs/ir/index.html)
+* [1.0.1 scalajs-logging]({{ site.production_url }}/api/scalajs-logging/1.0.1/org/scalajs/logging/index.html)
+* [1.0.1 scalajs-linker-interface]({{ site.production_url }}/api/scalajs-linker-interface/1.0.1/org/scalajs/linker/interface/index.html) ([Scala.js version]({{ site.production_url }}/api/scalajs-linker-interface-js/1.0.1/org/scalajs/linker/interface/index.html))
+* [1.0.1 scalajs-linker]({{ site.production_url }}/api/scalajs-linker/1.0.1/org/scalajs/linker/index.html) ([Scala.js version]({{ site.production_url }}/api/scalajs-linker-js/1.0.1/org/scalajs/linker/index.html))
+* [1.0.1 scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/1.0.1/org/scalajs/jsenv/index.html)
+* [1.0.1 scalajs-env-nodejs]({{ site.production_url }}/api/scalajs-env-nodejs/1.0.1/org/scalajs/jsenv/nodejs/index.html)
+* [1.0.1 scalajs-js-envs-test-kit]({{ site.production_url }}/api/scalajs-js-envs-test-kit/1.0.1/org/scalajs/jsenv/test/index.html)
+* [1.0.1 scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/1.0.1/org/scalajs/testadapter/index.html)
+* [1.0.1 sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/1.0.1/#org.scalajs.sbtplugin.package)
+
 ### Scala.js 1.0.0
 * [1.0.0 scalajs-library]({{ site.production_url }}/api/scalajs-library/1.0.0/scala/scalajs/js/index.html)
 * [1.0.0 scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/1.0.0/)

--- a/doc/internals/version-history.md
+++ b/doc/internals/version-history.md
@@ -6,6 +6,7 @@ title: Version history
 ## Version history of Scala.js
 
 - [1.0.0](/news/2020/02/25/announcing-scalajs-1.0.0/)
+- [1.0.1](/news/2020/03/10/announcing-scalajs-1.0.1/)
 - [0.6.32](/news/2020/01/24/announcing-scalajs-0.6.32/)
 - [1.0.0-RC2](/news/2019/12/13/announcing-scalajs-1.0.0-RC2/)
 - [1.0.0-RC1](/news/2019/11/26/announcing-scalajs-1.0.0-RC1/)


### PR DESCRIPTION
Note: this does not contain new links for downloads of the CLI. We need to figure out a process for building and uploading the CLI post-1.0.0.