### PR TITLE
Fix instanceOfs linker config for Scala.js 1.x

### DIFF
--- a/doc/semantics.md
+++ b/doc/semantics.md
@@ -145,6 +145,11 @@ JVM semantics, you can do so with an sbt setting.
 For example, this setting enables compliant `asInstanceOf`s:
 
 {% highlight scala %}
+// Scala.js 1.x
+scalaJSLinkerConfig ~= { _.withSemantics(_.withAsInstanceOfs(
+  org.scalajs.linker.interface.CheckedBehavior.Compliant)) }
+
+// Scala.js 0.6.x
 scalaJSLinkerConfig ~= { _.withSemantics(_.withAsInstanceOfs(
   org.scalajs.core.tools.sem.CheckedBehavior.Compliant)) }
 {% endhighlight %}


### PR DESCRIPTION
In Scala.js 1.x `CheckedBehavior` is under `org.scalajs.linker.interface.CheckedBehavior`, and no longer `org.scalajs.core.tools.sem.CheckedBehavior`. This PR updates the website's documentation to reflect that.