### PR TITLE
Remove the links to the latest APIs for JS envs and logging.

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -10,12 +10,8 @@ title: Scala.js API
 * [scalajs-library]({{ site.production_url }}/api/scalajs-library/latest/scala/scalajs/js/index.html)
 * [scalajs-test-interface]({{ site.production_url }}/api/scalajs-test-interface/latest/)
 * [scalajs-ir]({{ site.production_url }}/api/scalajs-ir/latest/org/scalajs/ir/index.html)
-* [scalajs-logging]({{ site.production_url }}/api/scalajs-logging/latest/org/scalajs/logging/index.html)
 * [scalajs-linker-interface]({{ site.production_url }}/api/scalajs-linker-interface/latest/org/scalajs/linker/interface/index.html) ([Scala.js version]({{ site.production_url }}/api/scalajs-linker-interface-js/latest/org/scalajs/linker/interface/index.html))
 * [scalajs-linker]({{ site.production_url }}/api/scalajs-linker/latest/org/scalajs/linker/index.html) ([Scala.js version]({{ site.production_url }}/api/scalajs-linker-js/latest/org/scalajs/linker/index.html))
-* [scalajs-js-envs]({{ site.production_url }}/api/scalajs-js-envs/latest/org/scalajs/jsenv/index.html)
-* [scalajs-env-nodejs]({{ site.production_url }}/api/scalajs-env-nodejs/latest/org/scalajs/jsenv/nodejs/index.html)
-* [scalajs-js-envs-test-kit]({{ site.production_url }}/api/scalajs-js-envs-test-kit/latest/org/scalajs/jsenv/test/index.html)
 * [scalajs-test-adapter]({{ site.production_url }}/api/scalajs-sbt-test-adapter/latest/org/scalajs/testing/adapter/index.html)
 * [sbt-scalajs]({{ site.production_url }}/api/sbt-scalajs/latest/#org.scalajs.sbtplugin.package)
 


### PR DESCRIPTION
They now have their own repos with their own API hosting.