### PR TITLE
Basic tutorial: mention jsdom prerequisite upfront

### DIFF
--- a/doc/tutorial/basic/0.6.x.md
+++ b/doc/tutorial/basic/0.6.x.md
@@ -15,6 +15,8 @@ To go through this tutorial, you will need to [download & install sbt](https://w
 
 You will also need to [download & install Node.js](https://nodejs.org/en/download/).
 
+To run the complete tutorial application, you will also need to install jsdom as explained [below](#supporting-the-dom).
+
 ## <a name="setup"></a> Step 1: Setup
 
 First create a new folder where your sbt project will go.

--- a/doc/tutorial/basic/index.md
+++ b/doc/tutorial/basic/index.md
@@ -13,6 +13,8 @@ To go through this tutorial, you will need to [download & install sbt](https://w
 
 You will also need to [download & install Node.js](https://nodejs.org/en/download/).
 
+To run the complete tutorial application, you will also need to install jsdom as explained [below](#supporting-the-dom).
+
 ## <a name="setup"></a> Step 1: Setup
 
 First create a new folder where your sbt project will go.


### PR DESCRIPTION
Prompted by a SO [question](https://stackoverflow.com/questions/64393465/how-can-i-get-the-scala-js-1-3-0-tutorial-to-run-part-2/64394115#64394115). Some people will try to run the complete app in the github repo before reading the tutorial in full, so I figured we could mention the need for jsdom more prominently, in the prerequisites section.