### PR TITLE
Do not reference boostrapping skeleton anymore

### DIFF
--- a/doc/project/index.md
+++ b/doc/project/index.md
@@ -5,7 +5,7 @@ title: Scala.js project structure
 
 
 Scala.js comes with an sbt plugin that facilitates compiling, running and testing with Scala.js. For a quick start, 
-have a look at our [bootstrapping skeleton](https://github.com/sjrd/scala-js-example-app).
+have a look at our [basic tutorial](../tutorial/basic/).
 
 Load the sbt plugin (`project/plugins.sbt`)
 


### PR DESCRIPTION
It says its not maintained. Reference the tutorial instead.