### PR TITLE
Getting started tutorial: Create a `package.json` to install the npm packages locally

### DIFF
--- a/doc/tutorial/basic/index.md
+++ b/doc/tutorial/basic/index.md
@@ -335,7 +335,13 @@ jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
 {% endhighlight %}
 
 This will use the [`jsdom`](https://github.com/jsdom/jsdom) library to simulate a DOM in Node.js.
-Note that you need to install it separately using
+You need to install it separately.
+It is usually best to install it locally for this project.
+You can initialize a private `package.json` as follows:
+
+    $ npm init private
+
+Then you can install jsdom:
 
     $ npm install jsdom
 


### PR DESCRIPTION
Without a `package.json` npm packages are installed in the home directory (or inside the first  ancestor directory containing a `package.json`)

I'm not sure if this change is an improvement and perhaps you had a specific reason not to use a `package.json` file. Nonetheless following the tutorial has a side-effect on the follower's environment. 


