### PR TITLE
tutorial: Create a `package.json` in an earlier step

### DIFF
--- a/doc/tutorial/basic/index.md
+++ b/doc/tutorial/basic/index.md
@@ -81,6 +81,12 @@ Congratulations! You have successfully compiled and run your first Scala.js appl
 The code is actually run by a JavaScript interpreter, namely Node.
 
 **Source maps in Node.js**: To get your stack traces resolved on Node.js, you will have to install the `source-map-support` package.
+It is usually best to install it locally for this project.
+You can initialize a private `package.json` as follows:
+
+    $ npm init private
+
+Then you can install `source-map-support`:
 
     $ npm install source-map-support
 
@@ -335,13 +341,7 @@ jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
 {% endhighlight %}
 
 This will use the [`jsdom`](https://github.com/jsdom/jsdom) library to simulate a DOM in Node.js.
-You need to install it separately.
-It is usually best to install it locally for this project.
-You can initialize a private `package.json` as follows:
-
-    $ npm init private
-
-Then you can install jsdom:
+Note that you need to install it separately using
 
     $ npm install jsdom
 


### PR DESCRIPTION
A student of mine noticed that the first npm package installed is `source-map-support `. Moved the generation of the package.json up in the tutorial.

