### PR TITLE
Update links on doc landing page

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -13,8 +13,10 @@ Scala.js with respect to JavaScript.
 
 All you need to get started is 
 
-* A recent version of Java JDK [(download)](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-* SBT [(download)](http://www.scala-sbt.org/0.13/tutorial/Setup.html)
+* A recent version of Java JDK [(download)](https://www.oracle.com/java/technologies/downloads/)
+* SBT [(download)](https://www.scala-sbt.org/1.x/docs/Setup.html)
+
+See the [Basic tutorial](tutorial/basic/) for details about installation and setup.
 
 # Tutorials
 


### PR DESCRIPTION
The sbt link was obsolete.

Also updated Oracle link, although the previous link is still forwarded to the JDK 8 section.

I just wanted to find the latest version number for scala-js, which is buried at the basic tutorial.

The old sbt link made me think I was on an old doc page, so I despaired.

There is an effort underway to make the beginner experience less confusing, which should mitigate the despairing.