### PR TITLE
Refer to scalajs-stubs 1.1.0 instead of 1.0.0 in cross build docs

### DIFF
--- a/doc/project/cross-build.md
+++ b/doc/project/cross-build.md
@@ -108,7 +108,7 @@ In order for the annotated classes to compile on the JVM project, you should add
 {% highlight scala %}
   .jvmSettings(
     ...
-    libraryDependencies += "org.scala-js" %% "scalajs-stubs" % "1.0.0" % "provided",
+    libraryDependencies += "org.scala-js" %% "scalajs-stubs" % "1.1.0" % "provided",
   )
 {% endhighlight %}
 


### PR DESCRIPTION
Hi :)

The cross build docs refer to scalajs-stubs 1.0.0, but 1.10 is already out. Also, 1.0.0 is not published for scala 3, which is why I noticed it at all.

This PR just bumps the version