### PR TITLE
Fix the permalink for 1.5.1

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -32,4 +32,5 @@ redirect 301 /community/libraries/skeletons.html /libraries/skeletons.html
 redirect 301 /community/libraries/testing.html /libraries/testing.html
 redirect 301 /community/libraries/ /libraries/
 
+redirect 301 /news/2020/11/16/announcing-scalajs-1.5.1/ {{ BASE_PATH }}/news/2021/04/01/announcing-scalajs-1.5.1/
 redirect 301 /news/2021-10-07/announcing-scalajs-1.7.1/ {{ BASE_PATH }}/news/2021/10/07/announcing-scalajs-1.7.1/

--- a/_posts/news/2021-04-01-announcing-scalajs-1.5.1.md
+++ b/_posts/news/2021-04-01-announcing-scalajs-1.5.1.md
@@ -3,7 +3,7 @@ layout: post
 title: Announcing Scala.js 1.5.1
 category: news
 tags: [releases]
-permalink: /news/2020/11/16/announcing-scalajs-1.5.1/
+permalink: /news/2021/04/01/announcing-scalajs-1.5.1/
 ---
 
 


### PR DESCRIPTION
This is the URI referenced in https://github.com/scala-js/scala-js-website/blob/main/doc/internals/version-history.md