### PR TITLE
Add a Docker-based setup.

### DIFF
--- a/.asset-cache/.gitkeep
+++ b/.asset-cache/.gitkeep
@@ -1,0 +1,3 @@
+This directory is required for the docker volume hackery (see Dockerfile) to work.
+
+https://stackoverflow.com/questions/37883895/can-i-have-a-writable-docker-volume-mounted-under-a-read-only-volume

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM ruby:2.7.5-bullseye
+
+# We need Node.js for the `execjs` gem, used by `_plugins/tokenize.rb`
+# Since it is a (sufficiently) standalone binary, we can just copy it from the node image.
+# Note that both the ruby and node docker images are based off buildpack-deps so they have
+# essentially the same base.
+COPY --from=node:18.14-bullseye /usr/local/bin/node /usr/local/bin/node
+
+RUN gem install bundler:2.3.10
+
+WORKDIR /srv/jekyll
+
+COPY Gemfile .
+COPY Gemfile.lock .
+
+RUN bundle install
+
+# jekyll serve will listen to port 4000
+EXPOSE 4000
+
+# declare volumes for jekyll output
+# Unfortunately jekyll 3.x isn't sufficiently configurable to not write to the
+# output directory.
+#
+# The docker-compose file will ro mount the sources to /srv/jekyll,
+# and then (implicitly) create anonymous volumes at these locations.
+#
+# A better approach (for jekyll 4.x) would be to set
+# --destination to a different location and also set
+# --disable-disk-cache to avoid creating .asset-cache.
+VOLUME ["/srv/jekyll/.asset-cache", "/srv/jekyll/_site"]
+
+CMD ["bundle", "exec", "jekyll", "serve", "--watch", "--host=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,30 @@ The key to contributing is being able to edit and
 preview your content. [Your pull requests are welcome](https://github.com/scala-js/scala-js-website/compare)!
 
 ## Set up
+
+### With Docker
+
+You need to have [Docker Engine](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/) installed on your machine.
+Under Mac OS (Intel or Apple silicon), instead of installing [Docker Desktop](https://docs.docker.com/desktop/) you can also use [HomeBrew](https://brew.sh/) with [Colima](https://github.com/abiosoft/colima): `brew install colima docker docker-compose`.
+
+```
+docker-compose up --build
+```
+
+On Linux you may have to prefix that command with `sudo`, depending on your Docker setup.
+
+The generated site is available at `http://localhost:4000`.
+
+When the website dependencies change (the content of the `Gemfile`), you have to kill and re-run the command.
+
+If you have problems with the Docker image or want to force the rebuild of the Docker image:
+
+```
+docker-compose build --no-cache
+```
+
+### Manually with Ruby tooling
+
 As this website is built with [Jekyll](http://jekyllrb.com/),
 we will need to set up some Ruby tooling.
 
@@ -22,7 +46,7 @@ $ rvm use 2.7.5 --install
 
 # Set up Bundler, a Ruby package manager
 # It downloads dependencies specified in a Gemfile
-# but into a local path unlike gem 
+# but into a local path unlike gem
 $ gem install bundler
  # and if this fails, try installing libffi first (distro-specific):
  # sudo apt install libffi-dev
@@ -34,8 +58,9 @@ $ bundle install
 $ bundle exec jekyll build
 ```
 
-## Editing live
-This is what you would do after initial installation:
+#### Editing live
+
+This is what you would do after the initial installation:
 ```bash
 $ bundle exec jekyll serve --watch
 ```

--- a/_site/.gitkeep
+++ b/_site/.gitkeep
@@ -1,0 +1,3 @@
+This directory is required for the docker volume hackery (see Dockerfile) to work.
+
+https://stackoverflow.com/questions/37883895/can-i-have-a-writable-docker-volume-mounted-under-a-read-only-volume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  jekyll:
+    build: .
+    ports:
+      - '4000:4000'
+    volumes:
+      - .:/srv/jekyll:ro


### PR DESCRIPTION
Based off #600.

I can't run Ruby 2.7.x on my machine anymore. Docker was the only solution I found. It may help others getting started to contribute to this website as well.

The setup is inspired by that of `scala-lang.org`, but modified to avoid UID hacker (instead has some volume hackery).