### PR TITLE
Do not expose generated dev docker site to the internet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   jekyll:
     build: .
     ports:
-      - '4000:4000'
+      - '127.0.0.1:4000:4000'
     volumes:
       - .:/srv/jekyll:ro


### PR DESCRIPTION
By default, published docker ports "bind" to all inbound addresses. We restrict to localhost to avoid exposing the site to the internet.

Note that malicious same L2 participants can still reach the container due to:
https://github.com/moby/moby/issues/45610