### PR TITLE
Updates related to scala-js-env-playwright v0.1.11 release

### DIFF
--- a/doc/project/js-environments.md
+++ b/doc/project/js-environments.md
@@ -69,14 +69,14 @@ jsEnv := PhantomJSEnv(args = Seq("arg1", "arg2")).value
 For more options of the PhantomJS environment, see
 [the Scaladoc of `PhantomJSEnv`]({{ site.production_url }}/api/sbt-scalajs-env-phantomjs/1.0.0/org/scalajs/jsenv/phantomjs/sbtplugin/PhantomJSEnvPlugin$$autoImport$.html).
 
-## Playwright 
-[Playwright](https://playwright.dev/) is a comprehensive testing library, enabling automation of Chromium, Firefox, and WebKit browsers. 
+## Playwright
+[Playwright](https://playwright.dev/) is a comprehensive testing library, enabling automation of Chromium, Firefox, and WebKit browsers.
 
-It supports multiple platforms and languages, including Mobile Web, making it an optimal choice for testing JavaScript in real browser environments. 
+It supports multiple platforms and languages, including Mobile Web, making it an optimal choice for testing JavaScript in real browser environments.
 
 [`scala-js-env-playwright`](https://github.com/gmkumar2005/scala-js-env-playwright) is an independent project that offers a `JSEnv` that uses Playwright for JavaScript execution.
 
-The playwright-based `jsEnv` can be enabled by adding the following settings in `build.sbt` 
+The playwright-based `jsEnv` can be enabled by adding the following settings in `build.sbt`
 ```scala
 jsEnv := new PWEnv(
         browserName = "chrome",
@@ -87,39 +87,35 @@ jsEnv := new PWEnv(
 Addtionally it requires the following line in `project/plugins.sbt`:
 ```scala
 // For Scala.js 1.x
-libraryDependencies += "io.github.gmkumar2005" %% "scala-js-env-playwright" % "0.1.8"
+libraryDependencies += "io.github.gmkumar2005" %% "scala-js-env-playwright" % "0.1.11"
 ```
-
-The `browserName` parameter accepts `chrome` , `chromium` , `firefox`, and `webkit` as possible options. 
-
+The `browserName` parameter accepts `chrome` , `chromium` , `firefox`, and `webkit` as possible options.
 Please be aware that webkit support is currently in an experimental stage.
+It is fully tested on macOS and your mileage may vary on other platforms.
 
 ### In browser debugging
-To maintain the browser window open post-execution, add the `withKeepAlive`  option into the environment.
+`keepAlive` is a work in progress. It is not fully functional yet.
+As a workaround introducing delay in the test cases may help to keep the browser alive.
 
+
+### Debugging
+Additional debug information can be enabled by setting `debug` to `true`.
+It will also print the version of the browser which is used.
 ```scala
-lazy val pwenvConfig = Def.setting {
-  jsenv.playwright.PWEnv
-    .Config()
-    .withKeepAlive(true)
-}
-
-jsEnv := new jsenv.playwright.PWEnv(
-  browserName = "chrome",
-  headless = true,
-  showLogs = true,
-  pwenvConfig.value,
-)
-
+jsEnv := new PWEnv(
+        browserName = "chrome",
+        headless = true,
+        debug = true
+    )
 ``` 
 ### Headless Usage
-Running in headless mode is crucial for operations within Docker containers and build servers. 
+Running in headless mode is crucial for operations within Docker containers and build servers.
 
 By default, `scala-js-env-playwright` operates in headless mode.
 However, for debugging purposes, you can set headless to `false`.
 
-## Details
-For more options of the plawwright environment see the github project [PlayWright-jsEnv](https://github.com/gmkumar2005/scala-js-env-playwright)
+### Details
+For more options of the playWright environment see the github project [PlayWright-jsEnv](https://github.com/gmkumar2005/scala-js-env-playwright)
 
 ## Selenium
 


### PR DESCRIPTION
The `scala-js-env-playwright` is updated to `v0.1.11`. 
Release notes : https://github.com/gmkumar2005/scala-js-env-playwright/releases/tag/v0.1.11
