### PR TITLE
Change scalajs-crossproject version to 1.2.0

### DIFF
--- a/doc/project/cross-build.md
+++ b/doc/project/cross-build.md
@@ -32,7 +32,7 @@ First, you need to add `sbt-scalajs-crossproject` in your `project/plugins.sbt` 
 
 {% highlight scala %}
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "{{ site.versions.scalaJS }}")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 {% endhighlight %}
 
 You can then use the `crossProject` builder in your `build.sbt` file:


### PR DESCRIPTION
As of writing the latest version of sbt-scalajs-crossproject is 1.2.0 as listed on the repository of sbt-crossproject https://github.com/portable-scala/sbt-crossproject. This is a helpful change as being on 1.0.0 can introduce errors.