### PR TITLE
Add a None case for the laminar tutorial 'Editing counts'

### DIFF
--- a/doc/tutorial/laminar.md
+++ b/doc/tutorial/laminar.md
@@ -720,6 +720,7 @@ As an approximation of its behavior, itt wraps a UI-from-data binder `<--` and a
         value <-- valueSignal.map(_.toString),
         onInput.mapToValue.map(_.toIntOption).collect {
           case Some(newCount) => newCount
+          case None => 0
         } --> valueUpdater,
       ),
     )


### PR DESCRIPTION
This make it more consistent with the other inputs and (in my opinion) works more like I would expect. If I backspace to remove everything in the input, it just puts zero there.